### PR TITLE
feat: unify profiles design across categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.31.1",
+        "@radix-ui/react-progress": "^1.1.7",
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.539.0",
+        "motion": "^12.23.12",
         "next": "15.4.6",
         "pocketbase": "^0.26.2",
         "react": "19.1.0",
@@ -999,6 +1001,101 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1326,7 +1423,7 @@
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1335,7 +1432,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -4465,6 +4562,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.12.tgz",
+      "integrity": "sha512-8jCD8uW5GD1csOoqh1WhH1A6j5APHVE15nuBkFeRiMzYBdRwyAHmSP/oXSuW0WJPZRXTFdBoG4hY9TFWNhhwng==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.23.12",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/motion-dom": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.31.1",
+    "@radix-ui/react-progress": "^1.1.7",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.539.0",
+    "motion": "^12.23.12",
     "next": "15.4.6",
     "pocketbase": "^0.26.2",
     "react": "19.1.0",

--- a/src/app/(app)/buscar-freelancer/page.tsx
+++ b/src/app/(app)/buscar-freelancer/page.tsx
@@ -1,6 +1,15 @@
 import JobsList from "@/components/jobs/jobs-list";
 
-export default function BuscarFreelancerPage() {
+function buildQuery(sp: Record<string, string | undefined>) {
+  const q = new URLSearchParams();
+  Object.entries(sp).forEach(([k, v]) => {
+    if (v) q.set(k, String(v));
+  });
+  return q.toString();
+}
+
+export default function BuscarFreelancerPage({ searchParams }: { searchParams?: Record<string, string> }) {
+  const page = Number(searchParams?.page || 1);
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-4xl px-6 py-8">
@@ -9,7 +18,15 @@ export default function BuscarFreelancerPage() {
         <div className="mt-6">
           {/* Listado de trabajos activos */}
           {/* @ts-expect-error Async Server Component */}
-          <JobsList />
+          <JobsList page={page} perPage={12} />
+          <div className="mt-6 flex justify-center">
+            <a
+              className="btn btn-outline"
+              href={`?${buildQuery({ ...searchParams, page: String(page + 1) })}`}
+            >
+              Cargar más
+            </a>
+          </div>
         </div>
       </section>
     </main>

--- a/src/app/(app)/cargar-trabajo/page.tsx
+++ b/src/app/(app)/cargar-trabajo/page.tsx
@@ -1,0 +1,10 @@
+export default function CargarTrabajoPage() {
+  return (
+    <main className="min-h-[calc(100vh-80px)] bg-white">
+      <section className="mx-auto max-w-6xl px-6 py-8">
+        <h1 className="text-2xl font-semibold text-black">Cargar trabajo</h1>
+        <p className="mt-1 text-sm text-black/80">Publica tu oportunidad laboral aquí.</p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/cargar-trabajo/page.tsx
+++ b/src/app/(app)/cargar-trabajo/page.tsx
@@ -4,8 +4,8 @@ export default function CargarTrabajoPage() {
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-black">Cargar trabajo</h1>
-        <p className="mt-1 text-sm text-black/80">Publica tu oportunidad laboral aquí.</p>
+        <h1 className="text-2xl font-semibold text-brand">Cargar trabajo</h1>
+        <p className="mt-1 text-sm text-brand/80">Publica tu oportunidad laboral aquí.</p>
         <JobForm />
       </section>
     </main>

--- a/src/app/(app)/cargar-trabajo/page.tsx
+++ b/src/app/(app)/cargar-trabajo/page.tsx
@@ -1,9 +1,12 @@
+import JobForm from "@/components/jobs/job-form";
+
 export default function CargarTrabajoPage() {
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
         <h1 className="text-2xl font-semibold text-black">Cargar trabajo</h1>
         <p className="mt-1 text-sm text-black/80">Publica tu oportunidad laboral aquí.</p>
+        <JobForm />
       </section>
     </main>
   );

--- a/src/app/(app)/creadores/page.tsx
+++ b/src/app/(app)/creadores/page.tsx
@@ -7,8 +7,8 @@ export default function CreadoresPage({ searchParams }: { searchParams?: Record<
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-black/90">Creadores</h1>
-        <p className="mt-1 text-sm text-black/60">Talento creativo para impulsar tu marca.</p>
+        <h1 className="text-2xl font-semibold text-brand">Creadores</h1>
+        <p className="mt-1 text-sm text-brand/80">Talento creativo para impulsar tu marca.</p>
         <div className="mt-6">
           <ProfilesHeader category="creators" />
         </div>

--- a/src/app/(app)/creadores/page.tsx
+++ b/src/app/(app)/creadores/page.tsx
@@ -1,5 +1,5 @@
 import ProfilesList from "@/components/profiles/profiles-list";
-import ProfilesFilters from "@/components/profiles/profiles-filters";
+import ProfilesHeader from "@/components/profiles/profiles-header";
 import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
 
@@ -10,7 +10,7 @@ export default function CreadoresPage({ searchParams }: { searchParams?: Record<
         <h1 className="text-2xl font-semibold text-black/90">Creadores</h1>
         <p className="mt-1 text-sm text-black/60">Talento creativo para impulsar tu marca.</p>
         <div className="mt-6">
-          <ProfilesFilters category="creators" />
+          <ProfilesHeader category="creators" />
         </div>
         <div className="mt-6">
           <Suspense fallback={<ProfilesSkeleton />}>

--- a/src/app/(app)/creadores/page.tsx
+++ b/src/app/(app)/creadores/page.tsx
@@ -3,7 +3,16 @@ import ProfilesHeader from "@/components/profiles/profiles-header";
 import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
 
+function buildQuery(sp: Record<string, string | undefined>) {
+  const q = new URLSearchParams();
+  Object.entries(sp).forEach(([k, v]) => {
+    if (v) q.set(k, String(v));
+  });
+  return q.toString();
+}
+
 export default function CreadoresPage({ searchParams }: { searchParams?: Record<string, string> }) {
+  const page = Number(searchParams?.page || 1);
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
@@ -18,8 +27,14 @@ export default function CreadoresPage({ searchParams }: { searchParams?: Record<
             <ProfilesList
               category="creators"
               filters={{ q: searchParams?.q, subcat: searchParams?.subcat, city: searchParams?.city, hood: searchParams?.hood }}
+              page={page}
             />
           </Suspense>
+        </div>
+        <div className="mt-6 flex justify-center">
+          <a className="btn btn-outline" href={`?${buildQuery({ ...searchParams, page: String(page + 1) })}`}>
+            Cargar más
+          </a>
         </div>
       </section>
     </main>

--- a/src/app/(app)/creadores/page.tsx
+++ b/src/app/(app)/creadores/page.tsx
@@ -7,8 +7,8 @@ export default function CreadoresPage({ searchParams }: { searchParams?: Record<
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-brand">Creadores</h1>
-        <p className="mt-1 text-sm text-brand/80">Talento creativo para impulsar tu marca.</p>
+        <h1 className="text-2xl font-semibold text-black">Creadores</h1>
+        <p className="mt-1 text-sm text-black/80">Talento creativo para impulsar tu marca.</p>
         <div className="mt-6">
           <ProfilesHeader category="creators" />
         </div>

--- a/src/app/(app)/oficios/page.tsx
+++ b/src/app/(app)/oficios/page.tsx
@@ -3,7 +3,16 @@ import ProfilesHeader from "@/components/profiles/profiles-header";
 import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
 
+function buildQuery(sp: Record<string, string | undefined>) {
+  const q = new URLSearchParams();
+  Object.entries(sp).forEach(([k, v]) => {
+    if (v) q.set(k, String(v));
+  });
+  return q.toString();
+}
+
 export default function OficiosPage({ searchParams }: { searchParams?: Record<string, string> }) {
+  const page = Number(searchParams?.page || 1);
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
@@ -18,8 +27,14 @@ export default function OficiosPage({ searchParams }: { searchParams?: Record<st
             <ProfilesList
               category="workers"
               filters={{ q: searchParams?.q, subcat: searchParams?.subcat, city: searchParams?.city, hood: searchParams?.hood }}
-            />
+              page={page}
+              />
           </Suspense>
+        </div>
+        <div className="mt-6 flex justify-center">
+          <a className="btn btn-outline" href={`?${buildQuery({ ...searchParams, page: String(page + 1) })}`}>
+            Cargar más
+          </a>
         </div>
       </section>
     </main>

--- a/src/app/(app)/oficios/page.tsx
+++ b/src/app/(app)/oficios/page.tsx
@@ -7,8 +7,8 @@ export default function OficiosPage({ searchParams }: { searchParams?: Record<st
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-black/90">Profesionales de Oficios</h1>
-        <p className="mt-1 text-sm text-black/60">Profesionales verificados para tus necesidades.</p>
+        <h1 className="text-2xl font-semibold text-brand">Profesionales de Oficios</h1>
+        <p className="mt-1 text-sm text-brand/80">Profesionales verificados para tus necesidades.</p>
         <div className="mt-6">
           <ProfilesHeader category="workers" />
         </div>

--- a/src/app/(app)/oficios/page.tsx
+++ b/src/app/(app)/oficios/page.tsx
@@ -1,5 +1,5 @@
 import ProfilesList from "@/components/profiles/profiles-list";
-import ProfilesFilters from "@/components/profiles/profiles-filters";
+import ProfilesHeader from "@/components/profiles/profiles-header";
 import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
 
@@ -7,10 +7,10 @@ export default function OficiosPage({ searchParams }: { searchParams?: Record<st
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-black/90">Oficios</h1>
+        <h1 className="text-2xl font-semibold text-black/90">Profesionales de Oficios</h1>
         <p className="mt-1 text-sm text-black/60">Profesionales verificados para tus necesidades.</p>
         <div className="mt-6">
-          <ProfilesFilters category="workers" />
+          <ProfilesHeader category="workers" />
         </div>
         <div className="mt-6">
           <Suspense fallback={<ProfilesSkeleton />}>

--- a/src/app/(app)/oficios/page.tsx
+++ b/src/app/(app)/oficios/page.tsx
@@ -7,8 +7,8 @@ export default function OficiosPage({ searchParams }: { searchParams?: Record<st
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-brand">Profesionales de Oficios</h1>
-        <p className="mt-1 text-sm text-brand/80">Profesionales verificados para tus necesidades.</p>
+        <h1 className="text-2xl font-semibold text-black">Profesionales de Oficios</h1>
+        <p className="mt-1 text-sm text-black/80">Profesionales verificados para tus necesidades.</p>
         <div className="mt-6">
           <ProfilesHeader category="workers" />
         </div>

--- a/src/app/(app)/proveedores/page.tsx
+++ b/src/app/(app)/proveedores/page.tsx
@@ -7,8 +7,8 @@ export default function ProveedoresPage({ searchParams }: { searchParams?: Recor
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-black/90">Proveedores</h1>
-        <p className="mt-1 text-sm text-black/60">Productos y servicios para tu negocio.</p>
+        <h1 className="text-2xl font-semibold text-brand">Proveedores</h1>
+        <p className="mt-1 text-sm text-brand/80">Productos y servicios para tu negocio.</p>
         <div className="mt-6">
           <ProfilesHeader category="providers" />
         </div>

--- a/src/app/(app)/proveedores/page.tsx
+++ b/src/app/(app)/proveedores/page.tsx
@@ -1,5 +1,5 @@
 import ProfilesList from "@/components/profiles/profiles-list";
-import ProfilesFilters from "@/components/profiles/profiles-filters";
+import ProfilesHeader from "@/components/profiles/profiles-header";
 import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
 
@@ -10,7 +10,7 @@ export default function ProveedoresPage({ searchParams }: { searchParams?: Recor
         <h1 className="text-2xl font-semibold text-black/90">Proveedores</h1>
         <p className="mt-1 text-sm text-black/60">Productos y servicios para tu negocio.</p>
         <div className="mt-6">
-          <ProfilesFilters category="providers" />
+          <ProfilesHeader category="providers" />
         </div>
         <div className="mt-6">
           <Suspense fallback={<ProfilesSkeleton />}>

--- a/src/app/(app)/proveedores/page.tsx
+++ b/src/app/(app)/proveedores/page.tsx
@@ -3,7 +3,16 @@ import ProfilesHeader from "@/components/profiles/profiles-header";
 import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
 
+function buildQuery(sp: Record<string, string | undefined>) {
+  const q = new URLSearchParams();
+  Object.entries(sp).forEach(([k, v]) => {
+    if (v) q.set(k, String(v));
+  });
+  return q.toString();
+}
+
 export default function ProveedoresPage({ searchParams }: { searchParams?: Record<string, string> }) {
+  const page = Number(searchParams?.page || 1);
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
@@ -18,8 +27,14 @@ export default function ProveedoresPage({ searchParams }: { searchParams?: Recor
             <ProfilesList
               category="providers"
               filters={{ q: searchParams?.q, subcat: searchParams?.subcat, city: searchParams?.city, hood: searchParams?.hood }}
+              page={page}
             />
           </Suspense>
+        </div>
+        <div className="mt-6 flex justify-center">
+          <a className="btn btn-outline" href={`?${buildQuery({ ...searchParams, page: String(page + 1) })}`}>
+            Cargar más
+          </a>
         </div>
       </section>
     </main>

--- a/src/app/(app)/proveedores/page.tsx
+++ b/src/app/(app)/proveedores/page.tsx
@@ -7,8 +7,8 @@ export default function ProveedoresPage({ searchParams }: { searchParams?: Recor
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-brand">Proveedores</h1>
-        <p className="mt-1 text-sm text-brand/80">Productos y servicios para tu negocio.</p>
+        <h1 className="text-2xl font-semibold text-black">Proveedores</h1>
+        <p className="mt-1 text-sm text-black/80">Productos y servicios para tu negocio.</p>
         <div className="mt-6">
           <ProfilesHeader category="providers" />
         </div>

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { getPocketBase } from "@/services/pb";
+
+interface JobInput {
+  title: string;
+  description: string;
+  category: string;
+  subcategory?: string;
+  price?: number;
+  currency?: string;
+  price_unit?: string;
+  modality?: string;
+  status?: string;
+  expires_at?: string;
+  city?: string;
+  neighborhood?: string;
+}
+
+export async function POST(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  let body: JobInput;
+  try {
+    body = (await req.json()) as JobInput;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const pb = getPocketBase();
+
+  try {
+    const profile = await pb.collection("profiles").getFirstListItem(`clerk_id = "${userId}"`);
+    const record = await pb.collection("jobs").create({
+      ...body,
+      profile_id: profile.id,
+    });
+    return NextResponse.json({ record });
+  } catch (e: unknown) {
+    const error = e as { status?: number; message?: string };
+    const status = typeof error?.status === "number" ? error.status : 500;
+    return NextResponse.json({ error: error?.message || "PocketBase error" }, { status });
+  } finally {
+    pb.authStore.clear();
+  }
+}

--- a/src/components/jobs/job-form.tsx
+++ b/src/components/jobs/job-form.tsx
@@ -36,7 +36,8 @@ const initialData: FormData = {
 export default function JobForm() {
   const [data, setData] = useState<FormData>(initialData);
   const [loading, setLoading] = useState(false);
-  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [successUrl, setSuccessUrl] = useState<string | null>(null);
 
   function update<K extends keyof FormData>(key: K, value: FormData[K]) {
     setData((prev) => ({ ...prev, [key]: value }));
@@ -45,7 +46,7 @@ export default function JobForm() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
-    setMessage(null);
+    setError(null);
     const payload = {
       ...data,
       price: data.price ? Number(data.price) : undefined,
@@ -59,20 +60,25 @@ export default function JobForm() {
       });
       const json = await res.json();
       if (!res.ok) throw new Error(json.error || "Error");
-      setMessage("Trabajo creado correctamente");
+      const url = `${window.location.origin}/trabajo/${json.id}`;
+      setSuccessUrl(url);
       setData(initialData);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Error";
-      setMessage(msg);
+      setError(msg);
     } finally {
       setLoading(false);
     }
   }
 
   return (
-    <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+    <>
+      <form
+        onSubmit={handleSubmit}
+        className="mt-6 space-y-4 rounded-2xl border border-brand/10 bg-white p-6 shadow-sm"
+      >
       <div>
-        <label htmlFor="title" className="block text-sm font-medium text-black">
+        <label htmlFor="title" className="block text-sm font-medium text-brand">
           Título
         </label>
         <input
@@ -80,11 +86,12 @@ export default function JobForm() {
           value={data.title}
           onChange={(e) => update("title", e.target.value)}
           required
-          className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          placeholder="Ej: Electricista para obra"
+          className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
         />
       </div>
       <div>
-        <label htmlFor="description" className="block text-sm font-medium text-black">
+        <label htmlFor="description" className="block text-sm font-medium text-brand">
           Descripción
         </label>
         <textarea
@@ -93,12 +100,13 @@ export default function JobForm() {
           onChange={(e) => update("description", e.target.value)}
           rows={4}
           required
-          className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          placeholder="Detalles del trabajo..."
+          className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
         />
       </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div>
-          <label htmlFor="category" className="block text-sm font-medium text-black">
+          <label htmlFor="category" className="block text-sm font-medium text-brand">
             Categoría
           </label>
           <select
@@ -107,7 +115,7 @@ export default function JobForm() {
             onChange={(e) =>
               setData((prev) => ({ ...prev, category: e.target.value as CategoryKey, subcategory: "" }))
             }
-            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+            className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           >
             {Object.entries(CATEGORY_LABEL).map(([key, label]) => (
               <option key={key} value={key}>
@@ -117,14 +125,14 @@ export default function JobForm() {
           </select>
         </div>
         <div>
-          <label htmlFor="subcategory" className="block text-sm font-medium text-black">
+          <label htmlFor="subcategory" className="block text-sm font-medium text-brand">
             Subcategoría
           </label>
           <select
             id="subcategory"
             value={data.subcategory}
             onChange={(e) => update("subcategory", e.target.value)}
-            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+            className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           >
             <option value="">Selecciona...</option>
             {SUBCATEGORY_OPTIONS[data.category].map((o) => (
@@ -137,7 +145,7 @@ export default function JobForm() {
       </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <div>
-          <label htmlFor="price" className="block text-sm font-medium text-black">
+          <label htmlFor="price" className="block text-sm font-medium text-brand">
             Precio
           </label>
           <input
@@ -145,59 +153,64 @@ export default function JobForm() {
             type="number"
             value={data.price ?? ""}
             onChange={(e) => update("price", e.target.value ? Number(e.target.value) : undefined)}
-            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+            placeholder="Monto"
+            className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
         </div>
         <div>
-          <label htmlFor="currency" className="block text-sm font-medium text-black">
+          <label htmlFor="currency" className="block text-sm font-medium text-brand">
             Moneda
           </label>
           <input
             id="currency"
             value={data.currency}
             onChange={(e) => update("currency", e.target.value)}
-            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+            placeholder="ARS"
+            className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
         </div>
         <div>
-          <label htmlFor="price_unit" className="block text-sm font-medium text-black">
+          <label htmlFor="price_unit" className="block text-sm font-medium text-brand">
             Unidad
           </label>
           <input
             id="price_unit"
             value={data.price_unit}
             onChange={(e) => update("price_unit", e.target.value)}
-            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+            placeholder="hora"
+            className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
         </div>
       </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div>
-          <label htmlFor="modality" className="block text-sm font-medium text-black">
+          <label htmlFor="modality" className="block text-sm font-medium text-brand">
             Modalidad
           </label>
           <input
             id="modality"
             value={data.modality}
             onChange={(e) => update("modality", e.target.value)}
-            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+            placeholder="full_time"
+            className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
         </div>
         <div>
-          <label htmlFor="status" className="block text-sm font-medium text-black">
+          <label htmlFor="status" className="block text-sm font-medium text-brand">
             Estado
           </label>
           <input
             id="status"
             value={data.status}
             onChange={(e) => update("status", e.target.value)}
-            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+            placeholder="active"
+            className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
         </div>
       </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
         <div>
-          <label htmlFor="expires_at" className="block text-sm font-medium text-black">
+          <label htmlFor="expires_at" className="block text-sm font-medium text-brand">
             Expira el
           </label>
           <input
@@ -205,41 +218,64 @@ export default function JobForm() {
             type="date"
             value={data.expires_at}
             onChange={(e) => update("expires_at", e.target.value)}
-            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+            className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
         </div>
         <div>
-          <label htmlFor="city" className="block text-sm font-medium text-black">
+          <label htmlFor="city" className="block text-sm font-medium text-brand">
             Ciudad
           </label>
           <input
             id="city"
             value={data.city}
             onChange={(e) => update("city", e.target.value)}
-            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+            placeholder="Ej: Buenos Aires"
+            className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
         </div>
         <div>
-          <label htmlFor="neighborhood" className="block text-sm font-medium text-black">
+          <label htmlFor="neighborhood" className="block text-sm font-medium text-brand">
             Barrio
           </label>
           <input
             id="neighborhood"
             value={data.neighborhood}
             onChange={(e) => update("neighborhood", e.target.value)}
-            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+            placeholder="Ej: Palermo"
+            className="mt-1 w-full rounded-lg border border-brand/20 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
           />
         </div>
       </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
       <button
         type="submit"
         disabled={loading}
-        className="h-10 rounded-lg bg-brand px-4 text-sm font-medium text-brand-foreground"
+        className="h-10 rounded-lg bg-brand px-4 text-sm font-medium text-brand-foreground disabled:opacity-50"
       >
         {loading ? "Enviando..." : "Publicar"}
       </button>
-      {message && <p className="text-sm text-black/80">{message}</p>}
     </form>
+      {successUrl && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="w-full max-w-sm rounded-lg bg-white p-6 text-center shadow-lg">
+            <h2 className="text-lg font-semibold text-brand">¡Trabajo creado!</h2>
+            <p className="mt-2 text-sm text-black/70">Compartí este enlace:</p>
+            <a
+              href={successUrl}
+              className="mt-4 block break-words text-sm text-brand underline"
+            >
+              {successUrl}
+            </a>
+            <button
+              onClick={() => setSuccessUrl(null)}
+              className="mt-6 w-full rounded-md bg-brand px-4 py-2 text-sm font-medium text-brand-foreground"
+            >
+              Cerrar
+            </button>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/components/jobs/job-form.tsx
+++ b/src/components/jobs/job-form.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useState } from "react";
+import { CATEGORY_LABEL, SUBCATEGORY_OPTIONS, type CategoryKey } from "@/lib/categories";
+
+interface FormData {
+  title: string;
+  description: string;
+  category: CategoryKey;
+  subcategory: string;
+  price?: number;
+  currency: string;
+  price_unit: string;
+  modality: string;
+  status: string;
+  expires_at: string;
+  city: string;
+  neighborhood: string;
+}
+
+const initialData: FormData = {
+  title: "",
+  description: "",
+  category: "workers",
+  subcategory: "",
+  price: undefined,
+  currency: "ARS",
+  price_unit: "hour",
+  modality: "full_time",
+  status: "active",
+  expires_at: "",
+  city: "",
+  neighborhood: "",
+};
+
+export default function JobForm() {
+  const [data, setData] = useState<FormData>(initialData);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  function update<K extends keyof FormData>(key: K, value: FormData[K]) {
+    setData((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setMessage(null);
+    const payload = {
+      ...data,
+      price: data.price ? Number(data.price) : undefined,
+      expires_at: data.expires_at ? new Date(data.expires_at).toISOString() : undefined,
+    };
+    try {
+      const res = await fetch("/api/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Error");
+      setMessage("Trabajo creado correctamente");
+      setData(initialData);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Error";
+      setMessage(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+      <div>
+        <label htmlFor="title" className="block text-sm font-medium text-black">
+          Título
+        </label>
+        <input
+          id="title"
+          value={data.title}
+          onChange={(e) => update("title", e.target.value)}
+          required
+          className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+        />
+      </div>
+      <div>
+        <label htmlFor="description" className="block text-sm font-medium text-black">
+          Descripción
+        </label>
+        <textarea
+          id="description"
+          value={data.description}
+          onChange={(e) => update("description", e.target.value)}
+          rows={4}
+          required
+          className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+        />
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label htmlFor="category" className="block text-sm font-medium text-black">
+            Categoría
+          </label>
+          <select
+            id="category"
+            value={data.category}
+            onChange={(e) =>
+              setData((prev) => ({ ...prev, category: e.target.value as CategoryKey, subcategory: "" }))
+            }
+            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          >
+            {Object.entries(CATEGORY_LABEL).map(([key, label]) => (
+              <option key={key} value={key}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="subcategory" className="block text-sm font-medium text-black">
+            Subcategoría
+          </label>
+          <select
+            id="subcategory"
+            value={data.subcategory}
+            onChange={(e) => update("subcategory", e.target.value)}
+            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          >
+            <option value="">Selecciona...</option>
+            {SUBCATEGORY_OPTIONS[data.category].map((o) => (
+              <option key={o.key} value={o.key}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div>
+          <label htmlFor="price" className="block text-sm font-medium text-black">
+            Precio
+          </label>
+          <input
+            id="price"
+            type="number"
+            value={data.price ?? ""}
+            onChange={(e) => update("price", e.target.value ? Number(e.target.value) : undefined)}
+            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label htmlFor="currency" className="block text-sm font-medium text-black">
+            Moneda
+          </label>
+          <input
+            id="currency"
+            value={data.currency}
+            onChange={(e) => update("currency", e.target.value)}
+            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label htmlFor="price_unit" className="block text-sm font-medium text-black">
+            Unidad
+          </label>
+          <input
+            id="price_unit"
+            value={data.price_unit}
+            onChange={(e) => update("price_unit", e.target.value)}
+            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label htmlFor="modality" className="block text-sm font-medium text-black">
+            Modalidad
+          </label>
+          <input
+            id="modality"
+            value={data.modality}
+            onChange={(e) => update("modality", e.target.value)}
+            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label htmlFor="status" className="block text-sm font-medium text-black">
+            Estado
+          </label>
+          <input
+            id="status"
+            value={data.status}
+            onChange={(e) => update("status", e.target.value)}
+            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div>
+          <label htmlFor="expires_at" className="block text-sm font-medium text-black">
+            Expira el
+          </label>
+          <input
+            id="expires_at"
+            type="date"
+            value={data.expires_at}
+            onChange={(e) => update("expires_at", e.target.value)}
+            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label htmlFor="city" className="block text-sm font-medium text-black">
+            Ciudad
+          </label>
+          <input
+            id="city"
+            value={data.city}
+            onChange={(e) => update("city", e.target.value)}
+            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          />
+        </div>
+        <div>
+          <label htmlFor="neighborhood" className="block text-sm font-medium text-black">
+            Barrio
+          </label>
+          <input
+            id="neighborhood"
+            value={data.neighborhood}
+            onChange={(e) => update("neighborhood", e.target.value)}
+            className="mt-1 w-full rounded-lg border border-black/20 px-3 py-2 text-sm"
+          />
+        </div>
+      </div>
+      <button
+        type="submit"
+        disabled={loading}
+        className="h-10 rounded-lg bg-brand px-4 text-sm font-medium text-brand-foreground"
+      >
+        {loading ? "Enviando..." : "Publicar"}
+      </button>
+      {message && <p className="text-sm text-black/80">{message}</p>}
+    </form>
+  );
+}
+

--- a/src/components/jobs/jobs-list.tsx
+++ b/src/components/jobs/jobs-list.tsx
@@ -2,19 +2,20 @@ import PocketBase from "pocketbase";
 import JobsCard from "@/components/jobs/jobs-card";
 
 type JobsListProps = {
-  limit?: number;
+  perPage?: number;
+  page?: number;
 };
 
-export default async function JobsList({ limit = 12 }: JobsListProps) {
+export default async function JobsList({ perPage = 12, page = 1 }: JobsListProps) {
   const pbUrl = process.env.POCKETBASE_URL || "";
-  const token = process.env.POCKETBEASE_ADMIN_TOKEN || process.env.POCKETBASE_ADMIN_TOKEN || "";
+  const token = process.env.POCKETBASE_ADMIN_TOKEN || "";
   const pb = new PocketBase(pbUrl);
   if (token) pb.authStore.save(token, null);
 
   let items: any[] = [];
   try {
-    if (!pbUrl || !token) throw new Error("PB config missing");
-    const res = await pb.collection("jobs").getList(1, limit, {
+    if (!pbUrl || !token) throw new Error("PocketBase config missing");
+    const res = await pb.collection("jobs").getList(page, perPage, {
       filter: 'status = "active"',
       sort: "-created",
     });
@@ -43,4 +44,3 @@ export default async function JobsList({ limit = 12 }: JobsListProps) {
     </div>
   );
 }
-

--- a/src/components/nav/navbar1.tsx
+++ b/src/components/nav/navbar1.tsx
@@ -97,6 +97,9 @@ export function Navbar1({ logo = defaultLogo, menu = defaultMenu }: Navbar1Props
 
           {/* Right: Auth + Mobile menu */}
           <div className="justify-self-end flex items-center gap-2">
+            <Link href="/cargar-trabajo">
+              <Button size="sm">Cargar trabajo</Button>
+            </Link>
             <SignedOut>
               <SignInButton mode="modal">
                 <Button variant="outline" size="sm">Iniciar Sesión</Button>
@@ -143,6 +146,9 @@ export function Navbar1({ logo = defaultLogo, menu = defaultMenu }: Navbar1Props
                   )}
                 </div>
               ))}
+              <Link href="/cargar-trabajo" onClick={() => setOpen(false)}>
+                <Button className="w-full">Cargar trabajo</Button>
+              </Link>
               <div className="mt-4 flex flex-col gap-2">
                 <SignedOut>
                   <SignInButton mode="modal">

--- a/src/components/onboarding/progress.tsx
+++ b/src/components/onboarding/progress.tsx
@@ -1,22 +1,23 @@
 "use client";
 
-import * as Progress from "@radix-ui/react-progress";
-import { motion } from "motion/react";
+import { motion } from "framer-motion";
 
 export default function OnboardingProgress({ current, total }: { current: number; total: number }) {
   const pct = Math.round(((current + 1) / total) * 100);
   return (
     <div className="mb-4">
-      <Progress.Root className="h-2 w-full overflow-hidden rounded-full bg-black/5" value={pct}>
-        <Progress.Indicator asChild>
-          <motion.div
-            className="h-full bg-brand"
-            initial={{ width: 0 }}
-            animate={{ width: `${pct}%` }}
-            transition={{ type: "spring", bounce: 0.2 }}
-          />
-        </Progress.Indicator>
-      </Progress.Root>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-black/5">
+        <motion.div
+          className="h-2 rounded-full bg-brand"
+          initial={{ width: 0 }}
+          animate={{ width: `${pct}%` }}
+          transition={{ duration: 0.4 }}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={pct}
+          role="progressbar"
+        />
+      </div>
       <div className="mt-1 text-right text-xs text-black/60">{pct}%</div>
     </div>
   );

--- a/src/components/onboarding/progress.tsx
+++ b/src/components/onboarding/progress.tsx
@@ -1,19 +1,22 @@
 "use client";
 
+import * as Progress from "@radix-ui/react-progress";
+import { motion } from "motion/react";
+
 export default function OnboardingProgress({ current, total }: { current: number; total: number }) {
   const pct = Math.round(((current + 1) / total) * 100);
   return (
     <div className="mb-4">
-      <div className="h-2 w-full rounded-full bg-black/5">
-        <div
-          className="h-2 rounded-full bg-brand transition-all duration-500"
-          style={{ width: `${pct}%` }}
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={pct}
-          role="progressbar"
-        />
-      </div>
+      <Progress.Root className="h-2 w-full overflow-hidden rounded-full bg-black/5" value={pct}>
+        <Progress.Indicator asChild>
+          <motion.div
+            className="h-full bg-brand"
+            initial={{ width: 0 }}
+            animate={{ width: `${pct}%` }}
+            transition={{ type: "spring", bounce: 0.2 }}
+          />
+        </Progress.Indicator>
+      </Progress.Root>
       <div className="mt-1 text-right text-xs text-black/60">{pct}%</div>
     </div>
   );

--- a/src/components/onboarding/step-indicator.tsx
+++ b/src/components/onboarding/step-indicator.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { motion } from "motion/react";
+
 type StepIndicatorProps = {
   steps: string[];
   current: number;
@@ -12,14 +14,17 @@ export default function StepIndicator({ steps, current }: StepIndicatorProps) {
         const active = idx <= current;
         return (
           <li key={label} className="flex items-center gap-3">
-            <span
-              className={
-                "flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium " +
-                (active ? "bg-brand text-brand-foreground" : "bg-black/5 text-black/60")
-              }
+            <motion.span
+              className="flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium"
+              animate={{
+                backgroundColor: active ? "var(--brand)" : "rgba(0,0,0,0.05)",
+                color: active ? "var(--brand-foreground)" : "rgba(0,0,0,0.6)",
+                scale: active ? 1.1 : 1,
+              }}
+              transition={{ type: "spring", stiffness: 300, damping: 20 }}
             >
               {idx + 1}
-            </span>
+            </motion.span>
             <span className="text-sm font-medium text-black/70">{label}</span>
           </li>
         );

--- a/src/components/onboarding/transition-layout.tsx
+++ b/src/components/onboarding/transition-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion } from "motion/react";
 import { usePathname } from "next/navigation";
 
 const variants = {

--- a/src/components/onboarding/transition-layout.tsx
+++ b/src/components/onboarding/transition-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "motion/react";
+import { AnimatePresence, motion } from "framer-motion";
 import { usePathname } from "next/navigation";
 
 const variants = {
@@ -26,4 +26,3 @@ export default function OnboardingTransitionLayout({ children }: { children: Rea
     </AnimatePresence>
   );
 }
-

--- a/src/components/profiles/profile-card.tsx
+++ b/src/components/profiles/profile-card.tsx
@@ -17,22 +17,22 @@ export default function ProfileCard({ profile, subcategory }: { profile: Profile
   const image = profile.avatar ? fileUrl("profiles", profile.id, profile.avatar) : null;
 
   return (
-    <article className="group overflow-hidden rounded-2xl border border-black/10 bg-white shadow-sm transition hover:shadow-md">
+    <article className="group overflow-hidden rounded-2xl border border-brand/10 bg-white shadow-sm transition hover:shadow-md">
       {image ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img src={image} alt="Foto del perfil" className="h-40 w-full object-cover" />
       ) : (
-        <div className="h-40 w-full bg-black/5" />
+        <div className="h-40 w-full bg-brand/5" />
       )}
       <div className="grid gap-2 p-4">
         <div className="flex items-start justify-between gap-3">
-          <h3 className="text-base font-semibold text-black/90 line-clamp-1">{name}</h3>
+          <h3 className="line-clamp-1 text-base font-semibold text-foreground">{name}</h3>
           {typeof profile.rating === "number" && (
-            <span className="text-xs text-black/60">{profile.rating.toFixed(1)}</span>
+            <span className="text-xs text-brand">{profile.rating.toFixed(1)}</span>
           )}
         </div>
-        {subcategory && <div className="text-sm text-black/60">{subcategory}</div>}
-        {location && <div className="text-xs text-black/60">{location}</div>}
+        {subcategory && <div className="text-sm text-brand">{subcategory}</div>}
+        {location && <div className="text-xs text-muted-foreground">{location}</div>}
       </div>
     </article>
   );

--- a/src/components/profiles/profile-card.tsx
+++ b/src/components/profiles/profile-card.tsx
@@ -28,10 +28,10 @@ export default function ProfileCard({ profile, subcategory }: { profile: Profile
         <div className="flex items-start justify-between gap-3">
           <h3 className="line-clamp-1 text-base font-semibold text-foreground">{name}</h3>
           {typeof profile.rating === "number" && (
-            <span className="text-xs text-brand">{profile.rating.toFixed(1)}</span>
+            <span className="text-xs text-black">{profile.rating.toFixed(1)}</span>
           )}
         </div>
-        {subcategory && <div className="text-sm text-brand">{subcategory}</div>}
+        {subcategory && <div className="text-sm text-black">{subcategory}</div>}
         {location && <div className="text-xs text-muted-foreground">{location}</div>}
       </div>
     </article>

--- a/src/components/profiles/profile-card.tsx
+++ b/src/components/profiles/profile-card.tsx
@@ -1,25 +1,38 @@
+import { fileUrl } from "@/services/pb";
+
 type Profile = {
   id: string;
   first_name?: string;
   last_name?: string;
-  bio?: string;
   city?: string;
   country?: string;
   neighborhood?: string;
-  roles?: string[];
-  links?: any;
+  avatar?: string;
+  rating?: number;
 };
 
-export default function ProfileCard({ profile }: { profile: Profile }) {
+export default function ProfileCard({ profile, subcategory }: { profile: Profile; subcategory?: string }) {
   const name = [profile.first_name, profile.last_name].filter(Boolean).join(" ") || "Perfil";
   const location = [profile.neighborhood, profile.city, profile.country].filter(Boolean).join(", ");
+  const image = profile.avatar ? fileUrl("profiles", profile.id, profile.avatar) : null;
 
   return (
     <article className="group overflow-hidden rounded-2xl border border-black/10 bg-white shadow-sm transition hover:shadow-md">
+      {image ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={image} alt="Foto del perfil" className="h-40 w-full object-cover" />
+      ) : (
+        <div className="h-40 w-full bg-black/5" />
+      )}
       <div className="grid gap-2 p-4">
-        <h3 className="text-base font-semibold text-black/90 line-clamp-1">{name}</h3>
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="text-base font-semibold text-black/90 line-clamp-1">{name}</h3>
+          {typeof profile.rating === "number" && (
+            <span className="text-xs text-black/60">{profile.rating.toFixed(1)}</span>
+          )}
+        </div>
+        {subcategory && <div className="text-sm text-black/60">{subcategory}</div>}
         {location && <div className="text-xs text-black/60">{location}</div>}
-        {profile.bio && <p className="text-sm text-black/70 line-clamp-2">{profile.bio}</p>}
       </div>
     </article>
   );

--- a/src/components/profiles/profiles-filters.tsx
+++ b/src/components/profiles/profiles-filters.tsx
@@ -39,20 +39,20 @@ export default function ProfilesFilters({ category }: { category: CategoryKey })
     <div className="rounded-2xl border border-brand/10 bg-white p-4 shadow-sm">
       <div className="grid grid-cols-1 gap-3 md:grid-cols-5">
         <div className="md:col-span-2">
-          <label className="mb-1 block text-xs font-medium text-brand">Buscar</label>
+          <label className="mb-1 block text-xs font-medium text-black">Buscar</label>
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Nombre o bio"
-            className="h-10 w-full rounded-lg border border-brand/20 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
+            className="h-10 w-full rounded-lg border border-black bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/40"
           />
         </div>
         <div>
-          <label className="mb-1 block text-xs font-medium text-brand">Subcategoría</label>
+          <label className="mb-1 block text-xs font-medium text-black">Subcategoría</label>
           <select
             value={subcat}
             onChange={(e) => setSubcat(e.target.value)}
-            className="h-10 w-full rounded-lg border border-brand/20 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
+            className="h-10 w-full rounded-lg border border-black bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/40"
           >
             <option value="">Todas</option>
             {options.map((o) => (
@@ -63,21 +63,21 @@ export default function ProfilesFilters({ category }: { category: CategoryKey })
           </select>
         </div>
         <div>
-          <label className="mb-1 block text-xs font-medium text-brand">Ciudad</label>
+          <label className="mb-1 block text-xs font-medium text-black">Ciudad</label>
           <input
             value={city}
             onChange={(e) => setCity(e.target.value)}
             placeholder="Ciudad"
-            className="h-10 w-full rounded-lg border border-brand/20 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
+            className="h-10 w-full rounded-lg border border-black bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/40"
           />
         </div>
         <div>
-          <label className="mb-1 block text-xs font-medium text-brand">Barrio</label>
+          <label className="mb-1 block text-xs font-medium text-black">Barrio</label>
           <input
             value={hood}
             onChange={(e) => setHood(e.target.value)}
             placeholder="Barrio"
-            className="h-10 w-full rounded-lg border border-brand/20 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
+            className="h-10 w-full rounded-lg border border-black bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/40"
           />
         </div>
       </div>

--- a/src/components/profiles/profiles-filters.tsx
+++ b/src/components/profiles/profiles-filters.tsx
@@ -36,23 +36,23 @@ export default function ProfilesFilters({ category }: { category: CategoryKey })
   }
 
   return (
-    <div className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
+    <div className="rounded-2xl border border-brand/10 bg-white p-4 shadow-sm">
       <div className="grid grid-cols-1 gap-3 md:grid-cols-5">
         <div className="md:col-span-2">
-          <label className="mb-1 block text-xs font-medium text-black/70">Buscar</label>
+          <label className="mb-1 block text-xs font-medium text-brand">Buscar</label>
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Nombre o bio"
-            className="h-10 w-full rounded-lg border border-black/10 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/20"
+            className="h-10 w-full rounded-lg border border-brand/20 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
           />
         </div>
         <div>
-          <label className="mb-1 block text-xs font-medium text-black/70">Subcategoría</label>
+          <label className="mb-1 block text-xs font-medium text-brand">Subcategoría</label>
           <select
             value={subcat}
             onChange={(e) => setSubcat(e.target.value)}
-            className="h-10 w-full rounded-lg border border-black/10 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/20"
+            className="h-10 w-full rounded-lg border border-brand/20 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
           >
             <option value="">Todas</option>
             {options.map((o) => (
@@ -63,21 +63,21 @@ export default function ProfilesFilters({ category }: { category: CategoryKey })
           </select>
         </div>
         <div>
-          <label className="mb-1 block text-xs font-medium text-black/70">Ciudad</label>
+          <label className="mb-1 block text-xs font-medium text-brand">Ciudad</label>
           <input
             value={city}
             onChange={(e) => setCity(e.target.value)}
             placeholder="Ciudad"
-            className="h-10 w-full rounded-lg border border-black/10 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/20"
+            className="h-10 w-full rounded-lg border border-brand/20 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
           />
         </div>
         <div>
-          <label className="mb-1 block text-xs font-medium text-black/70">Barrio</label>
+          <label className="mb-1 block text-xs font-medium text-brand">Barrio</label>
           <input
             value={hood}
             onChange={(e) => setHood(e.target.value)}
             placeholder="Barrio"
-            className="h-10 w-full rounded-lg border border-black/10 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/20"
+            className="h-10 w-full rounded-lg border border-brand/20 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
           />
         </div>
       </div>

--- a/src/components/profiles/profiles-header.tsx
+++ b/src/components/profiles/profiles-header.tsx
@@ -11,6 +11,7 @@ export default function ProfilesHeader({ category }: { category: CategoryKey }) 
   const [isPending, startTransition] = useTransition();
 
   const [q, setQ] = useState(params.get("q") || "");
+  const [showFilters, setShowFilters] = useState(false);
   const currentSub = params.get("subcat") || "";
   const options = SUBCATEGORY_OPTIONS[category];
 
@@ -34,39 +35,48 @@ export default function ProfilesHeader({ category }: { category: CategoryKey }) 
 
   return (
     <div>
-      <form onSubmit={onSubmit}>
+      <form onSubmit={onSubmit} className="flex gap-2">
         <input
           value={q}
           onChange={(e) => setQ(e.target.value)}
           placeholder="Buscar profesionales por nombre, oficio o especialidad..."
-          className="h-10 w-full rounded-lg border border-black/10 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/20"
+          className="h-10 w-full flex-1 rounded-lg border border-brand/20 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
         />
-      </form>
-      <div className="mt-4 flex gap-2 overflow-x-auto">
         <button
-          onClick={() => updateSearch({ subcat: "" })}
-          className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
-            currentSub ? "border-black/10 text-black/60" : "border-black bg-black text-white"
-          }`}
-          disabled={isPending}
+          type="button"
+          onClick={() => setShowFilters((v) => !v)}
+          className="h-10 rounded-lg border border-brand bg-brand px-3 text-sm font-medium text-brand-foreground"
         >
-          Todos
+          Filtros
         </button>
-        {options.map((o) => (
+      </form>
+      {showFilters && (
+        <div className="mt-4 flex gap-2 overflow-x-auto">
           <button
-            key={o.key}
-            onClick={() => updateSearch({ subcat: o.key })}
+            onClick={() => updateSearch({ subcat: "" })}
             className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
-              currentSub === o.key
-                ? "border-black bg-black text-white"
-                : "border-black/10 text-black/60"
+              currentSub ? "border-brand/20 text-brand" : "border-brand bg-brand text-brand-foreground"
             }`}
             disabled={isPending}
           >
-            {o.label}
+            Todos
           </button>
-        ))}
-      </div>
+          {options.map((o) => (
+            <button
+              key={o.key}
+              onClick={() => updateSearch({ subcat: o.key })}
+              className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
+                currentSub === o.key
+                  ? "border-brand bg-brand text-brand-foreground"
+                  : "border-brand/20 text-brand"
+              }`}
+              disabled={isPending}
+            >
+              {o.label}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/profiles/profiles-header.tsx
+++ b/src/components/profiles/profiles-header.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState, useTransition } from "react";
+import { SUBCATEGORY_OPTIONS, type CategoryKey } from "@/lib/categories";
+
+export default function ProfilesHeader({ category }: { category: CategoryKey }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const [q, setQ] = useState(params.get("q") || "");
+  const currentSub = params.get("subcat") || "";
+  const options = SUBCATEGORY_OPTIONS[category];
+
+  function updateSearch(next: { q?: string; subcat?: string }) {
+    const sp = new URLSearchParams(params.toString());
+    if (next.q !== undefined) {
+      if (next.q) sp.set("q", next.q);
+      else sp.delete("q");
+    }
+    if (next.subcat !== undefined) {
+      if (next.subcat) sp.set("subcat", next.subcat);
+      else sp.delete("subcat");
+    }
+    startTransition(() => router.push(`${pathname}?${sp.toString()}`));
+  }
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    updateSearch({ q });
+  }
+
+  return (
+    <div>
+      <form onSubmit={onSubmit}>
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Buscar profesionales por nombre, oficio o especialidad..."
+          className="h-10 w-full rounded-lg border border-black/10 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/20"
+        />
+      </form>
+      <div className="mt-4 flex gap-2 overflow-x-auto">
+        <button
+          onClick={() => updateSearch({ subcat: "" })}
+          className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
+            currentSub ? "border-black/10 text-black/60" : "border-black bg-black text-white"
+          }`}
+          disabled={isPending}
+        >
+          Todos
+        </button>
+        {options.map((o) => (
+          <button
+            key={o.key}
+            onClick={() => updateSearch({ subcat: o.key })}
+            className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
+              currentSub === o.key
+                ? "border-black bg-black text-white"
+                : "border-black/10 text-black/60"
+            }`}
+            disabled={isPending}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/profiles/profiles-header.tsx
+++ b/src/components/profiles/profiles-header.tsx
@@ -40,7 +40,7 @@ export default function ProfilesHeader({ category }: { category: CategoryKey }) 
           value={q}
           onChange={(e) => setQ(e.target.value)}
           placeholder="Buscar profesionales por nombre, oficio o especialidad..."
-          className="h-10 w-full flex-1 rounded-lg border border-brand/20 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand/40"
+          className="h-10 w-full flex-1 rounded-lg border border-black bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/40"
         />
         <button
           type="button"
@@ -55,7 +55,7 @@ export default function ProfilesHeader({ category }: { category: CategoryKey }) 
           <button
             onClick={() => updateSearch({ subcat: "" })}
             className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
-              currentSub ? "border-brand/20 text-brand" : "border-brand bg-brand text-brand-foreground"
+              currentSub ? "border-brand/20 text-black" : "border-brand bg-brand text-brand-foreground"
             }`}
             disabled={isPending}
           >
@@ -68,7 +68,7 @@ export default function ProfilesHeader({ category }: { category: CategoryKey }) 
               className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
                 currentSub === o.key
                   ? "border-brand bg-brand text-brand-foreground"
-                  : "border-brand/20 text-brand"
+                  : "border-brand/20 text-black"
               }`}
               disabled={isPending}
             >

--- a/src/components/profiles/profiles-list.tsx
+++ b/src/components/profiles/profiles-list.tsx
@@ -1,10 +1,19 @@
 import { getPocketBase } from "@/services/pb";
 import ProfileCard from "@/components/profiles/profile-card";
+import { SUBCATEGORY_OPTIONS } from "@/lib/categories";
 
 type Category = "workers" | "creators" | "providers";
 
-export default async function ProfilesList({ category, limit = 30, filters }: { category: Category; limit?: number; filters?: { q?: string; subcat?: string; city?: string; hood?: string } }) {
-  let profiles: any[] = [];
+export default async function ProfilesList({
+  category,
+  limit = 30,
+  filters,
+}: {
+  category: Category;
+  limit?: number;
+  filters?: { q?: string; subcat?: string; city?: string; hood?: string };
+}) {
+  let profiles: { profile: any; subcat?: string }[] = [];
   try {
     const pb = getPocketBase();
     const subFilter = filters?.subcat ? ` && subcategory = "${filters.subcat}"` : "";
@@ -13,10 +22,10 @@ export default async function ProfilesList({ category, limit = 30, filters }: { 
       expand: "profile_id",
       sort: "-created",
     });
-    const map = new Map<string, any>();
+    const map = new Map<string, { profile: any; subcat?: string }>();
     for (const it of res.items) {
       const p = (it as any).expand?.profile_id;
-      if (p && !map.has(p.id)) map.set(p.id, p);
+      if (p && !map.has(p.id)) map.set(p.id, { profile: p, subcat: (it as any).subcategory });
     }
     profiles = Array.from(map.values());
 
@@ -24,7 +33,7 @@ export default async function ProfilesList({ category, limit = 30, filters }: { 
     const q = filters?.q?.toLowerCase().trim();
     const city = filters?.city?.toLowerCase().trim();
     const hood = filters?.hood?.toLowerCase().trim();
-    profiles = profiles.filter((p) => {
+    profiles = profiles.filter(({ profile: p }) => {
       const name = `${p.first_name || ""} ${p.last_name || ""}`.toLowerCase();
       const bio = (p.bio || "").toLowerCase();
       const pCity = (p.city || "").toLowerCase();
@@ -46,11 +55,16 @@ export default async function ProfilesList({ category, limit = 30, filters }: { 
     );
   }
 
+  const count = profiles.length;
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {profiles.map((p) => (
-        <ProfileCard key={p.id} profile={p} />
-      ))}
+    <div>
+      <div className="mb-4 text-sm text-black/60">{`Mostrando ${count} profesionales`}</div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {profiles.map(({ profile, subcat }) => {
+          const label = SUBCATEGORY_OPTIONS[category].find((o) => o.key === subcat)?.label;
+          return <ProfileCard key={profile.id} profile={profile} subcategory={label} />;
+        })}
+      </div>
     </div>
   );
 }

--- a/src/components/profiles/profiles-list.tsx
+++ b/src/components/profiles/profiles-list.tsx
@@ -8,16 +8,18 @@ export default async function ProfilesList({
   category,
   limit = 30,
   filters,
+  page = 1,
 }: {
   category: Category;
   limit?: number;
   filters?: { q?: string; subcat?: string; city?: string; hood?: string };
+  page?: number;
 }) {
   let profiles: { profile: any; subcat?: string }[] = [];
   try {
     const pb = getPocketBase();
     const subFilter = filters?.subcat ? ` && subcategory = "${filters.subcat}"` : "";
-    const res = await pb.collection("interests").getList(1, limit, {
+    const res = await pb.collection("interests").getList(page, limit, {
       filter: `category = "${category}"${subFilter}`,
       expand: "profile_id",
       sort: "-created",

--- a/src/components/profiles/profiles-list.tsx
+++ b/src/components/profiles/profiles-list.tsx
@@ -49,7 +49,7 @@ export default async function ProfilesList({
 
   if (!profiles.length) {
     return (
-      <div className="rounded-2xl border border-black/10 bg-white p-8 text-center text-sm text-black/60">
+      <div className="rounded-2xl border border-brand/10 bg-white p-8 text-center text-sm text-muted-foreground">
         No hay resultados por el momento.
       </div>
     );
@@ -58,7 +58,7 @@ export default async function ProfilesList({
   const count = profiles.length;
   return (
     <div>
-      <div className="mb-4 text-sm text-black/60">{`Mostrando ${count} profesionales`}</div>
+      <div className="mb-4 text-sm text-brand/80">{`Mostrando ${count} profesionales`}</div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {profiles.map(({ profile, subcat }) => {
           const label = SUBCATEGORY_OPTIONS[category].find((o) => o.key === subcat)?.label;

--- a/src/components/profiles/profiles-list.tsx
+++ b/src/components/profiles/profiles-list.tsx
@@ -58,7 +58,7 @@ export default async function ProfilesList({
   const count = profiles.length;
   return (
     <div>
-      <div className="mb-4 text-sm text-brand/80">{`Mostrando ${count} profesionales`}</div>
+      <div className="mb-4 text-sm text-black/80">{`Mostrando ${count} profesionales`}</div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {profiles.map(({ profile, subcat }) => {
           const label = SUBCATEGORY_OPTIONS[category].find((o) => o.key === subcat)?.label;

--- a/src/components/profiles/profiles-skeleton.tsx
+++ b/src/components/profiles/profiles-skeleton.tsx
@@ -2,7 +2,7 @@ export default function ProfilesSkeleton() {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {Array.from({ length: 6 }).map((_, i) => (
-        <div key={i} className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
+        <div key={i} className="rounded-2xl border border-brand/10 bg-white p-4 shadow-sm">
           <div className="skeleton mb-3 h-5 w-1/2"></div>
           <div className="skeleton mb-2 h-3 w-1/3"></div>
           <div className="skeleton h-4 w-full"></div>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,9 @@ const isPublicRoute = createRouteMatcher([
   "/sign-in(.*)",
   "/sign-up(.*)",
   "/api/webhooks/(.*)",
+  "/oficios(.*)",
+  "/creadores(.*)",
+  "/proveedores(.*)",
 ]);
 
 export default clerkMiddleware(async (auth, req) => {


### PR DESCRIPTION
## Summary
- add shared profiles header with search and subcategory chips
- show result count and subcategory labels on profile cards
- apply new listing layout to Oficios, Creadores and Proveedores pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a20eda80a48328af1ea1c846d411ab