### PR TITLE
feat: adopt shadcn ui and sweetalert2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,20 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.31.1",
+        "@radix-ui/react-progress": "^1.1.7",
+        "@radix-ui/react-slot": "^1.2.3",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.539.0",
+        "motion": "^12.23.12",
         "next": "15.4.6",
         "pocketbase": "^0.26.2",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "svix": "^1.73.0"
+        "svix": "^1.73.0",
+        "sweetalert2": "^11.22.4",
+        "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -999,6 +1006,101 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1326,7 +1428,7 @@
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1335,7 +1437,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2258,10 +2360,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -4467,6 +4590,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.12.tgz",
+      "integrity": "sha512-8jCD8uW5GD1csOoqh1WhH1A6j5APHVE15nuBkFeRiMzYBdRwyAHmSP/oXSuW0WJPZRXTFdBoG4hY9TFWNhhwng==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.23.12",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/motion-dom": {
       "version": "12.23.12",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
@@ -5573,6 +5722,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/sweetalert2": {
+      "version": "11.22.4",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.22.4.tgz",
+      "integrity": "sha512-JwcRODfozxiKmspFp+xctZ2izAmLAKbRPcoLMEW7LdugN/YmNrX1LT7hdBW87qsgupEO1ukBBuB17KzKFKW0tg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/limonte"
+      }
+    },
     "node_modules/swr": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
@@ -5583,6 +5742,16 @@
       },
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,20 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.31.1",
+    "@radix-ui/react-progress": "^1.1.7",
+    "@radix-ui/react-slot": "^1.2.3",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.539.0",
+    "motion": "^12.23.12",
     "next": "15.4.6",
     "pocketbase": "^0.26.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "svix": "^1.73.0"
+    "svix": "^1.73.0",
+    "sweetalert2": "^11.22.4",
+    "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/(app)/cargar-trabajo/page.tsx
+++ b/src/app/(app)/cargar-trabajo/page.tsx
@@ -1,0 +1,13 @@
+import JobForm from "@/components/jobs/job-form";
+
+export default function CargarTrabajoPage() {
+  return (
+    <main className="min-h-[calc(100vh-80px)] bg-white">
+      <section className="mx-auto max-w-6xl px-6 py-8">
+        <h1 className="text-2xl font-semibold text-brand">Cargar trabajo</h1>
+        <p className="mt-1 text-sm text-brand/80">Publica tu oportunidad laboral aquí.</p>
+        <JobForm />
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/cargar-trabajo/page.tsx
+++ b/src/app/(app)/cargar-trabajo/page.tsx
@@ -1,13 +1,10 @@
 import JobForm from "@/components/jobs/job-form";
+import PageShell from "@/components/layout/page-shell";
 
 export default function CargarTrabajoPage() {
   return (
-    <main className="min-h-[calc(100vh-80px)] bg-white">
-      <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-brand">Cargar trabajo</h1>
-        <p className="mt-1 text-sm text-brand/80">Publica tu oportunidad laboral aquí.</p>
-        <JobForm />
-      </section>
-    </main>
+    <PageShell title="Cargar trabajo" description="Publica tu oportunidad laboral aquí.">
+      <JobForm />
+    </PageShell>
   );
 }

--- a/src/app/(app)/creadores/page.tsx
+++ b/src/app/(app)/creadores/page.tsx
@@ -1,27 +1,20 @@
 import ProfilesList from "@/components/profiles/profiles-list";
 import ProfilesHeader from "@/components/profiles/profiles-header";
-import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
+import PageShell from "@/components/layout/page-shell";
+import { Suspense } from "react";
 
 export default function CreadoresPage({ searchParams }: { searchParams?: Record<string, string> }) {
   return (
-    <main className="min-h-[calc(100vh-80px)] bg-white">
-      <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-black">Creadores</h1>
-        <p className="mt-1 text-sm text-black/80">Talento creativo para impulsar tu marca.</p>
-        <div className="mt-6">
-          <ProfilesHeader category="creators" />
-        </div>
-        <div className="mt-6">
-          <Suspense fallback={<ProfilesSkeleton />}>
-            {/* @ts-expect-error Async Server Component */}
-            <ProfilesList
-              category="creators"
-              filters={{ q: searchParams?.q, subcat: searchParams?.subcat, city: searchParams?.city, hood: searchParams?.hood }}
-            />
-          </Suspense>
-        </div>
-      </section>
-    </main>
+    <PageShell title="Creadores" description="Talento creativo para impulsar tu marca.">
+      <ProfilesHeader category="creators" />
+      <Suspense fallback={<ProfilesSkeleton />}>
+        {/* @ts-expect-error Async Server Component */}
+        <ProfilesList
+          category="creators"
+          filters={{ q: searchParams?.q, subcat: searchParams?.subcat, city: searchParams?.city, hood: searchParams?.hood }}
+        />
+      </Suspense>
+    </PageShell>
   );
 }

--- a/src/app/(app)/creadores/page.tsx
+++ b/src/app/(app)/creadores/page.tsx
@@ -1,5 +1,5 @@
 import ProfilesList from "@/components/profiles/profiles-list";
-import ProfilesFilters from "@/components/profiles/profiles-filters";
+import ProfilesHeader from "@/components/profiles/profiles-header";
 import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
 
@@ -7,10 +7,10 @@ export default function CreadoresPage({ searchParams }: { searchParams?: Record<
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-black/90">Creadores</h1>
-        <p className="mt-1 text-sm text-black/60">Talento creativo para impulsar tu marca.</p>
+        <h1 className="text-2xl font-semibold text-black">Creadores</h1>
+        <p className="mt-1 text-sm text-black/80">Talento creativo para impulsar tu marca.</p>
         <div className="mt-6">
-          <ProfilesFilters category="creators" />
+          <ProfilesHeader category="creators" />
         </div>
         <div className="mt-6">
           <Suspense fallback={<ProfilesSkeleton />}>

--- a/src/app/(app)/oficios/page.tsx
+++ b/src/app/(app)/oficios/page.tsx
@@ -1,27 +1,20 @@
 import ProfilesList from "@/components/profiles/profiles-list";
 import ProfilesHeader from "@/components/profiles/profiles-header";
-import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
+import PageShell from "@/components/layout/page-shell";
+import { Suspense } from "react";
 
 export default function OficiosPage({ searchParams }: { searchParams?: Record<string, string> }) {
   return (
-    <main className="min-h-[calc(100vh-80px)] bg-white">
-      <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-black">Profesionales de Oficios</h1>
-        <p className="mt-1 text-sm text-black/80">Profesionales verificados para tus necesidades.</p>
-        <div className="mt-6">
-          <ProfilesHeader category="workers" />
-        </div>
-        <div className="mt-6">
-          <Suspense fallback={<ProfilesSkeleton />}>
-            {/* @ts-expect-error Async Server Component */}
-            <ProfilesList
-              category="workers"
-              filters={{ q: searchParams?.q, subcat: searchParams?.subcat, city: searchParams?.city, hood: searchParams?.hood }}
-            />
-          </Suspense>
-        </div>
-      </section>
-    </main>
+    <PageShell title="Profesionales de Oficios" description="Profesionales verificados para tus necesidades.">
+      <ProfilesHeader category="workers" />
+      <Suspense fallback={<ProfilesSkeleton />}>
+        {/* @ts-expect-error Async Server Component */}
+        <ProfilesList
+          category="workers"
+          filters={{ q: searchParams?.q, subcat: searchParams?.subcat, city: searchParams?.city, hood: searchParams?.hood }}
+        />
+      </Suspense>
+    </PageShell>
   );
 }

--- a/src/app/(app)/oficios/page.tsx
+++ b/src/app/(app)/oficios/page.tsx
@@ -1,5 +1,5 @@
 import ProfilesList from "@/components/profiles/profiles-list";
-import ProfilesFilters from "@/components/profiles/profiles-filters";
+import ProfilesHeader from "@/components/profiles/profiles-header";
 import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
 
@@ -7,10 +7,10 @@ export default function OficiosPage({ searchParams }: { searchParams?: Record<st
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-black/90">Oficios</h1>
-        <p className="mt-1 text-sm text-black/60">Profesionales verificados para tus necesidades.</p>
+        <h1 className="text-2xl font-semibold text-black">Profesionales de Oficios</h1>
+        <p className="mt-1 text-sm text-black/80">Profesionales verificados para tus necesidades.</p>
         <div className="mt-6">
-          <ProfilesFilters category="workers" />
+          <ProfilesHeader category="workers" />
         </div>
         <div className="mt-6">
           <Suspense fallback={<ProfilesSkeleton />}>

--- a/src/app/(app)/perfil/page.tsx
+++ b/src/app/(app)/perfil/page.tsx
@@ -1,0 +1,30 @@
+import { auth } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
+import { getPocketBase } from "@/services/pb";
+import ProfileForm from "@/components/profile/profile-form";
+
+export default async function PerfilPage() {
+  const { userId } = await auth();
+  if (!userId) redirect("/sign-in");
+
+  let profile: any = {};
+  try {
+    const pb = getPocketBase();
+    profile = await pb.collection("profiles").getFirstListItem(`clerk_id = "${userId}"`);
+  } catch {
+    profile = {};
+  }
+
+  return (
+    <main className="min-h-[calc(100vh-80px)] bg-white">
+      <section className="mx-auto max-w-3xl px-6 py-8">
+        <h1 className="text-2xl font-semibold text-black/90">Mi perfil</h1>
+        <p className="mt-1 text-sm text-black/60">Gestioná tus datos visibles en la plataforma.</p>
+
+        <div className="mt-6">
+          <ProfileForm initial={profile} />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/profesionales/[id]/page.tsx
+++ b/src/app/(app)/profesionales/[id]/page.tsx
@@ -1,0 +1,243 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getPocketBase, fileUrl } from "@/services/pb";
+import { SUBCATEGORY_OPTIONS, type CategoryKey } from "@/lib/categories";
+
+export const dynamic = "force-dynamic";
+
+type Profile = {
+  id: string;
+  first_name?: string;
+  last_name?: string;
+  bio?: string;
+  city?: string;
+  neighborhood?: string;
+  country?: string;
+  avatar?: string;
+  rating?: number;
+  created?: string;
+  jobs_completed?: number;
+  success_rate?: number;
+  on_time_rate?: number;
+};
+
+type Interest = { category: CategoryKey; subcategory?: string };
+
+type Portfolio = {
+  courses_url?: string;
+  diplomas_url?: string;
+};
+
+type Availability = {
+  day_of_week: string;
+  start_time: string;
+  end_time: string;
+  is_active?: boolean;
+};
+
+const CATEGORY_PATH: Record<CategoryKey, string> = {
+  workers: "oficios",
+  creators: "creadores",
+  providers: "proveedores",
+};
+
+const DAY_LABEL: Record<string, string> = {
+  monday: "Lunes",
+  tuesday: "Martes",
+  wednesday: "Miércoles",
+  thursday: "Jueves",
+  friday: "Viernes",
+  saturday: "Sábado",
+  sunday: "Domingo",
+};
+
+async function getProfile(id: string) {
+  const pb = getPocketBase();
+  try {
+    const profile = await pb.collection("profiles").getOne<Profile>(id);
+    const interestsRes = await pb
+      .collection("interests")
+      .getList<Interest>(1, 10, { filter: `profile_id = "${id}"` });
+    const portfolio = await pb
+      .collection("portfolios")
+      .getFirstListItem<Portfolio>(`profile_id = "${id}"`)
+      .catch(() => null);
+    const availabilityRes = await pb
+      .collection("weekly_availabilities")
+      .getList<Availability>(1, 20, { filter: `profile_id = "${id}"` })
+      .catch(() => ({ items: [] }));
+    return {
+      profile,
+      interests: interestsRes.items,
+      portfolio,
+      availability: availabilityRes.items,
+    };
+  } catch {
+    return null;
+  } finally {
+    pb.authStore.clear();
+  }
+}
+
+export default async function ProfessionalPage({ params }: { params: { id: string } }) {
+  const data = await getProfile(params.id);
+  if (!data) return notFound();
+  const { profile, interests, portfolio, availability } = data;
+
+  const name = [profile.first_name, profile.last_name].filter(Boolean).join(" ") || "Perfil";
+  const location = [profile.neighborhood, profile.city, profile.country].filter(Boolean).join(", ");
+  const avatar = profile.avatar ? fileUrl("profiles", profile.id, profile.avatar) : null;
+  const rating = typeof profile.rating === "number" ? profile.rating.toFixed(1) : null;
+
+  const mainInterest = interests[0];
+  const subcatLabel = mainInterest
+    ? SUBCATEGORY_OPTIONS[mainInterest.category]?.find((s) => s.key === mainInterest.subcategory)?.label
+    : undefined;
+  const backHref = mainInterest ? `/${CATEGORY_PATH[mainInterest.category]}` : "/oficios";
+
+  const memberSince = profile.created ? new Date(profile.created).getFullYear() : null;
+
+  const metrics = {
+    jobs: profile.jobs_completed ?? 0,
+    success: profile.success_rate ? `${profile.success_rate}%` : "0%",
+    onTime: profile.on_time_rate ? `${profile.on_time_rate}%` : "0%",
+    since: memberSince ?? "-",
+  };
+
+  const certs = [portfolio?.diplomas_url, portfolio?.courses_url].filter(Boolean) as string[];
+
+  const daysOrder = [
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+  ];
+  const availMap: Record<string, { start: string; end: string } | null> = {};
+  for (const d of daysOrder) availMap[d] = null;
+  for (const a of availability) {
+    if (a.is_active === false) continue;
+    availMap[a.day_of_week] = { start: a.start_time, end: a.end_time };
+  }
+
+  return (
+    <main className="min-h-[calc(100vh-80px)] bg-white">
+      <section className="mx-auto max-w-5xl px-6 py-8">
+        <div className="mb-4 text-sm">
+          <Link href={backHref} className="text-brand hover:underline">
+            ← Volver a profesionales
+          </Link>
+        </div>
+
+        <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-4">
+            {avatar ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={avatar}
+                alt={name}
+                className="h-20 w-20 rounded-full object-cover"
+              />
+            ) : (
+              <div className="h-20 w-20 rounded-full bg-brand/5" />
+            )}
+            <div>
+              <h1 className="text-2xl font-semibold text-foreground">{name}</h1>
+              {subcatLabel && <div className="text-sm text-black">{subcatLabel}</div>}
+              {rating && <div className="mt-1 text-sm text-black">⭐ {rating}</div>}
+              {location && <div className="mt-1 text-sm text-muted-foreground">{location}</div>}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button className="btn btn-primary">Contactar</button>
+            <button className="btn btn-outline">Guardar</button>
+            <button className="btn btn-outline">Compartir</button>
+          </div>
+        </div>
+
+        {profile.bio && (
+          <p className="mt-4 text-sm text-black/80">{profile.bio}</p>
+        )}
+
+        <div className="mt-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div className="rounded-xl border border-brand/10 bg-white p-4 text-center">
+            <div className="text-2xl font-semibold text-foreground">{metrics.jobs}</div>
+            <div className="text-xs text-muted-foreground">Trabajos</div>
+          </div>
+          <div className="rounded-xl border border-brand/10 bg-white p-4 text-center">
+            <div className="text-2xl font-semibold text-foreground">{metrics.success}</div>
+            <div className="text-xs text-muted-foreground">Tasa de éxito</div>
+          </div>
+          <div className="rounded-xl border border-brand/10 bg-white p-4 text-center">
+            <div className="text-2xl font-semibold text-foreground">{metrics.onTime}</div>
+            <div className="text-xs text-muted-foreground">Entregas a tiempo</div>
+          </div>
+          <div className="rounded-xl border border-brand/10 bg-white p-4 text-center">
+            <div className="text-2xl font-semibold text-foreground">{metrics.since}</div>
+            <div className="text-xs text-muted-foreground">Miembro desde</div>
+          </div>
+        </div>
+
+        <nav className="mt-8 flex gap-6 border-b border-brand/10 text-sm">
+          <span className="border-b-2 border-brand pb-2 font-medium text-brand">Resumen</span>
+          <span className="pb-2 text-muted-foreground">Servicios</span>
+          <span className="pb-2 text-muted-foreground">Portfolio</span>
+          <span className="pb-2 text-muted-foreground">Reseñas</span>
+        </nav>
+
+        <div className="mt-6 grid gap-6 lg:grid-cols-2">
+          <div className="rounded-2xl border border-brand/10 bg-white p-6">
+            <h2 className="mb-4 text-lg font-semibold text-foreground">Información General</h2>
+            <ul className="grid gap-2 text-sm text-black/80">
+              {memberSince && (
+                <li>
+                  <span className="font-medium">Miembro desde:</span> {memberSince}
+                </li>
+              )}
+              {location && (
+                <li>
+                  <span className="font-medium">Ubicación:</span> {location}
+                </li>
+              )}
+            </ul>
+          </div>
+
+          <div className="rounded-2xl border border-brand/10 bg-white p-6">
+            <h2 className="mb-4 text-lg font-semibold text-foreground">Certificaciones</h2>
+            {certs.length ? (
+              <ul className="grid gap-2 text-sm text-black/80">
+                {certs.map((c, i) => (
+                  <li key={i}>{c}</li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">Sin certificaciones</p>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-6 rounded-2xl border border-brand/10 bg-white p-6">
+          <h2 className="mb-4 text-lg font-semibold text-foreground">Disponibilidad</h2>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 md:grid-cols-7">
+            {daysOrder.map((d) => {
+              const slot = availMap[d];
+              return (
+                <div
+                  key={d}
+                  className="rounded-lg border border-brand/10 bg-white p-3 text-center"
+                >
+                  <div className="text-sm font-medium text-foreground">{DAY_LABEL[d]}</div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {slot ? `${slot.start} - ${slot.end}` : "No disponible"}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(app)/proveedores/page.tsx
+++ b/src/app/(app)/proveedores/page.tsx
@@ -1,5 +1,5 @@
 import ProfilesList from "@/components/profiles/profiles-list";
-import ProfilesFilters from "@/components/profiles/profiles-filters";
+import ProfilesHeader from "@/components/profiles/profiles-header";
 import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
 
@@ -7,10 +7,10 @@ export default function ProveedoresPage({ searchParams }: { searchParams?: Recor
   return (
     <main className="min-h-[calc(100vh-80px)] bg-white">
       <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-black/90">Proveedores</h1>
-        <p className="mt-1 text-sm text-black/60">Productos y servicios para tu negocio.</p>
+        <h1 className="text-2xl font-semibold text-black">Proveedores</h1>
+        <p className="mt-1 text-sm text-black/80">Productos y servicios para tu negocio.</p>
         <div className="mt-6">
-          <ProfilesFilters category="providers" />
+          <ProfilesHeader category="providers" />
         </div>
         <div className="mt-6">
           <Suspense fallback={<ProfilesSkeleton />}>

--- a/src/app/(app)/proveedores/page.tsx
+++ b/src/app/(app)/proveedores/page.tsx
@@ -1,27 +1,20 @@
 import ProfilesList from "@/components/profiles/profiles-list";
 import ProfilesHeader from "@/components/profiles/profiles-header";
-import { Suspense } from "react";
 import ProfilesSkeleton from "@/components/profiles/profiles-skeleton";
+import PageShell from "@/components/layout/page-shell";
+import { Suspense } from "react";
 
 export default function ProveedoresPage({ searchParams }: { searchParams?: Record<string, string> }) {
   return (
-    <main className="min-h-[calc(100vh-80px)] bg-white">
-      <section className="mx-auto max-w-6xl px-6 py-8">
-        <h1 className="text-2xl font-semibold text-black">Proveedores</h1>
-        <p className="mt-1 text-sm text-black/80">Productos y servicios para tu negocio.</p>
-        <div className="mt-6">
-          <ProfilesHeader category="providers" />
-        </div>
-        <div className="mt-6">
-          <Suspense fallback={<ProfilesSkeleton />}>
-            {/* @ts-expect-error Async Server Component */}
-            <ProfilesList
-              category="providers"
-              filters={{ q: searchParams?.q, subcat: searchParams?.subcat, city: searchParams?.city, hood: searchParams?.hood }}
-            />
-          </Suspense>
-        </div>
-      </section>
-    </main>
+    <PageShell title="Proveedores" description="Productos y servicios para tu negocio.">
+      <ProfilesHeader category="providers" />
+      <Suspense fallback={<ProfilesSkeleton />}>
+        {/* @ts-expect-error Async Server Component */}
+        <ProfilesList
+          category="providers"
+          filters={{ q: searchParams?.q, subcat: searchParams?.subcat, city: searchParams?.city, hood: searchParams?.hood }}
+        />
+      </Suspense>
+    </PageShell>
   );
 }

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { getPocketBase } from "@/services/pb";
+
+interface JobInput {
+  title: string;
+  description: string;
+  category: string;
+  subcategory?: string;
+  price?: number;
+  currency?: string;
+  price_unit?: string;
+  modality?: string;
+  status?: string;
+  expires_at?: string;
+  city?: string;
+  neighborhood?: string;
+}
+
+export async function POST(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  let body: JobInput;
+  try {
+    body = (await req.json()) as JobInput;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const pb = getPocketBase();
+
+  try {
+    const profile = await pb.collection("profiles").getFirstListItem(`clerk_id = "${userId}"`);
+    const record = await pb.collection("jobs").create({
+      ...body,
+      profile_id: profile.id,
+    });
+    return NextResponse.json({ record });
+  } catch (e: unknown) {
+    const error = e as { status?: number; message?: string };
+    const status = typeof error?.status === "number" ? error.status : 500;
+    return NextResponse.json({ error: error?.message || "PocketBase error" }, { status });
+  } finally {
+    pb.authStore.clear();
+  }
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -24,3 +24,45 @@ export async function GET(_req: NextRequest) {
   }
 }
 
+export async function PATCH(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  let body: any = {};
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const pbUrl = process.env.POCKETBASE_URL || "https://pocketbase-trabajaya.srv.clostech.tech";
+  const token = process.env.POCKETBASE_ADMIN_TOKEN;
+  if (!token) return NextResponse.json({ error: "Missing POCKETBASE_ADMIN_TOKEN" }, { status: 500 });
+
+  const pb = new PocketBase(pbUrl);
+  pb.authStore.save(token, null);
+
+  try {
+    const record = await pb.collection("profiles").getFirstListItem(`clerk_id = "${userId}"`);
+    const patch: Record<string, unknown> = {};
+    const allowed = [
+      "first_name",
+      "last_name",
+      "phone_number",
+      "bio",
+      "country",
+      "city",
+      "neighborhood",
+    ];
+    for (const key of allowed) {
+      if (body[key] !== undefined) patch[key] = body[key];
+    }
+    const updated = await pb.collection("profiles").update(record.id, patch);
+    return NextResponse.json({ ok: true, record: updated });
+  } catch (e: any) {
+    const status = typeof e?.status === "number" ? e.status : 500;
+    return NextResponse.json({ error: e?.message || "PocketBase error" }, { status });
+  } finally {
+    pb.authStore.clear();
+  }
+}

--- a/src/components/jobs/job-form.tsx
+++ b/src/components/jobs/job-form.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useState } from "react";
+import Swal from "sweetalert2";
+import { CATEGORY_LABEL, SUBCATEGORY_OPTIONS, type CategoryKey } from "@/lib/categories";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+interface FormData {
+  title: string;
+  description: string;
+  category: CategoryKey;
+  subcategory: string;
+  price?: number;
+  currency: string;
+  price_unit: string;
+  modality: string;
+  status: string;
+  expires_at: string;
+  city: string;
+  neighborhood: string;
+}
+
+const initialData: FormData = {
+  title: "",
+  description: "",
+  category: "workers",
+  subcategory: "",
+  price: undefined,
+  currency: "ARS",
+  price_unit: "hour",
+  modality: "full_time",
+  status: "active",
+  expires_at: "",
+  city: "",
+  neighborhood: "",
+};
+
+export default function JobForm() {
+  const [data, setData] = useState<FormData>(initialData);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function update<K extends keyof FormData>(key: K, value: FormData[K]) {
+    setData((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    const payload = {
+      ...data,
+      price: data.price ? Number(data.price) : undefined,
+      expires_at: data.expires_at ? new Date(data.expires_at).toISOString() : undefined,
+    };
+    try {
+      const res = await fetch("/api/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Error");
+      const url = `${window.location.origin}/trabajo/${json.id}`;
+      setData(initialData);
+      Swal.fire({
+        title: "¡Trabajo creado!",
+        html: `<a href="${url}" class="underline text-brand" target="_blank">${url}</a>`,
+        icon: "success",
+      });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Error";
+      setError(msg);
+      Swal.fire({ title: "Error", text: msg, icon: "error" });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <form
+        onSubmit={handleSubmit}
+        className="mt-6 space-y-4 rounded-2xl border border-brand/10 bg-white p-6 shadow-sm"
+      >
+        <div>
+          <Label htmlFor="title">Título</Label>
+          <Input
+            id="title"
+            value={data.title}
+            onChange={(e) => update("title", e.target.value)}
+            required
+            placeholder="Ej: Electricista para obra"
+            className="mt-1"
+          />
+        </div>
+        <div>
+          <Label htmlFor="description">Descripción</Label>
+          <Textarea
+            id="description"
+            value={data.description}
+            onChange={(e) => update("description", e.target.value)}
+            rows={4}
+            required
+            placeholder="Detalles del trabajo..."
+            className="mt-1"
+          />
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <Label htmlFor="category">Categoría</Label>
+            <select
+              id="category"
+              value={data.category}
+              onChange={(e) =>
+                setData((prev) => ({ ...prev, category: e.target.value as CategoryKey, subcategory: "" }))
+              }
+              className="mt-1 w-full rounded-md border border-brand/20 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+            >
+              {Object.entries(CATEGORY_LABEL).map(([key, label]) => (
+                <option key={key} value={key}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <Label htmlFor="subcategory">Subcategoría</Label>
+            <select
+              id="subcategory"
+              value={data.subcategory}
+              onChange={(e) => update("subcategory", e.target.value)}
+              className="mt-1 w-full rounded-md border border-brand/20 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand"
+            >
+              <option value="">Selecciona...</option>
+              {SUBCATEGORY_OPTIONS[data.category].map((o) => (
+                <option key={o.key} value={o.key}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div>
+            <Label htmlFor="price">Precio</Label>
+            <Input
+              id="price"
+              type="number"
+              value={data.price ?? ""}
+              onChange={(e) => update("price", e.target.value ? Number(e.target.value) : undefined)}
+              placeholder="Monto"
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <Label htmlFor="currency">Moneda</Label>
+            <Input
+              id="currency"
+              value={data.currency}
+              onChange={(e) => update("currency", e.target.value)}
+              placeholder="ARS"
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <Label htmlFor="price_unit">Unidad</Label>
+            <Input
+              id="price_unit"
+              value={data.price_unit}
+              onChange={(e) => update("price_unit", e.target.value)}
+              placeholder="hora"
+              className="mt-1"
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <Label htmlFor="modality">Modalidad</Label>
+            <Input
+              id="modality"
+              value={data.modality}
+              onChange={(e) => update("modality", e.target.value)}
+              placeholder="full_time"
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <Label htmlFor="status">Estado</Label>
+            <Input
+              id="status"
+              value={data.status}
+              onChange={(e) => update("status", e.target.value)}
+              placeholder="active"
+              className="mt-1"
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div>
+            <Label htmlFor="expires_at">Expira el</Label>
+            <Input
+              id="expires_at"
+              type="date"
+              value={data.expires_at}
+              onChange={(e) => update("expires_at", e.target.value)}
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <Label htmlFor="city">Ciudad</Label>
+            <Input
+              id="city"
+              value={data.city}
+              onChange={(e) => update("city", e.target.value)}
+              placeholder="Ej: Buenos Aires"
+              className="mt-1"
+            />
+          </div>
+          <div>
+            <Label htmlFor="neighborhood">Barrio</Label>
+            <Input
+              id="neighborhood"
+              value={data.neighborhood}
+              onChange={(e) => update("neighborhood", e.target.value)}
+              placeholder="Ej: Palermo"
+              className="mt-1"
+            />
+          </div>
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <Button type="submit" disabled={loading} className="mt-2">
+          {loading ? "Enviando..." : "Publicar"}
+        </Button>
+      </form>
+    </>
+  );
+}
+

--- a/src/components/layout/page-shell.tsx
+++ b/src/components/layout/page-shell.tsx
@@ -13,8 +13,8 @@ export default function PageShell({
     <main className="bg-muted min-h-[calc(100vh-80px)] py-8">
       <section className="mx-auto max-w-6xl px-6">
         <div className="rounded-2xl bg-white p-8 shadow-sm">
-          <h1 className="text-2xl font-semibold text-brand">{title}</h1>
-          <p className="mt-1 text-sm text-brand/80">{description}</p>
+          <h1 className="text-2xl font-semibold text-black">{title}</h1>
+          <p className="mt-1 text-sm text-black/80">{description}</p>
           <div className="mt-6 space-y-6">{children}</div>
         </div>
       </section>

--- a/src/components/layout/page-shell.tsx
+++ b/src/components/layout/page-shell.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+export default function PageShell({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="bg-muted min-h-[calc(100vh-80px)] py-8">
+      <section className="mx-auto max-w-6xl px-6">
+        <div className="rounded-2xl bg-white p-8 shadow-sm">
+          <h1 className="text-2xl font-semibold text-brand">{title}</h1>
+          <p className="mt-1 text-sm text-brand/80">{description}</p>
+          <div className="mt-6 space-y-6">{children}</div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/nav/navbar1.tsx
+++ b/src/components/nav/navbar1.tsx
@@ -60,7 +60,7 @@ export function Navbar1({ logo = defaultLogo, menu = defaultMenu }: Navbar1Props
   return (
     <header className="w-full border-b border-black/10 bg-white">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid h-16 grid-cols-[auto_1fr_auto] items-center">
+        <div className="grid h-16 lg:h-20 grid-cols-[auto_1fr_auto] items-center">
           {/* Left: Logo */}
           <div className="justify-self-start">
             <Link href={logo.url} className="flex items-center gap-2" aria-label={logo.title}>

--- a/src/components/nav/navbar1.tsx
+++ b/src/components/nav/navbar1.tsx
@@ -65,7 +65,13 @@ export function Navbar1({ logo = defaultLogo, menu = defaultMenu }: Navbar1Props
           <div className="justify-self-start">
             <Link href={logo.url} className="flex items-center gap-2" aria-label={logo.title}>
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={logo.src} width={200} height={60} className="h-14 w-auto" alt={logo.alt} />
+              <img
+                src={logo.src}
+                width={240}
+                height={72}
+                className="h-16 w-auto"
+                alt={logo.alt}
+              />
             </Link>
           </div>
 
@@ -125,7 +131,7 @@ export function Navbar1({ logo = defaultLogo, menu = defaultMenu }: Navbar1Props
             <div className="mb-4 flex items-center justify-between">
               <Link href={logo.url} className="flex items-center gap-2" onClick={() => setOpen(false)}>
                 {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={logo.src} className="max-h-8" alt={logo.alt} />
+                <img src={logo.src} className="h-12 w-auto" alt={logo.alt} />
               </Link>
               <Button variant="outline" size="icon" onClick={() => setOpen(false)} aria-label="Cerrar">×</Button>
             </div>

--- a/src/components/nav/navbar1.tsx
+++ b/src/components/nav/navbar1.tsx
@@ -97,6 +97,9 @@ export function Navbar1({ logo = defaultLogo, menu = defaultMenu }: Navbar1Props
 
           {/* Right: Auth + Mobile menu */}
           <div className="justify-self-end flex items-center gap-2">
+            <Link href="/cargar-trabajo">
+              <Button size="sm">Cargar trabajo</Button>
+            </Link>
             <SignedOut>
               <SignInButton mode="modal">
                 <Button variant="outline" size="sm">Iniciar Sesión</Button>
@@ -143,6 +146,9 @@ export function Navbar1({ logo = defaultLogo, menu = defaultMenu }: Navbar1Props
                   )}
                 </div>
               ))}
+              <Link href="/cargar-trabajo" onClick={() => setOpen(false)}>
+                <Button className="w-full">Cargar trabajo</Button>
+              </Link>
               <div className="mt-4 flex flex-col gap-2">
                 <SignedOut>
                   <SignInButton mode="modal">

--- a/src/components/onboarding/progress.tsx
+++ b/src/components/onboarding/progress.tsx
@@ -1,19 +1,22 @@
 "use client";
 
+import * as Progress from "@radix-ui/react-progress";
+import { motion } from "motion/react";
+
 export default function OnboardingProgress({ current, total }: { current: number; total: number }) {
   const pct = Math.round(((current + 1) / total) * 100);
   return (
     <div className="mb-4">
-      <div className="h-2 w-full rounded-full bg-black/5">
-        <div
-          className="h-2 rounded-full bg-brand transition-all duration-500"
-          style={{ width: `${pct}%` }}
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={pct}
-          role="progressbar"
-        />
-      </div>
+      <Progress.Root className="h-2 w-full overflow-hidden rounded-full bg-black/5" value={pct}>
+        <Progress.Indicator asChild>
+          <motion.div
+            className="h-full bg-brand"
+            initial={{ width: 0 }}
+            animate={{ width: `${pct}%` }}
+            transition={{ type: "spring", bounce: 0.2 }}
+          />
+        </Progress.Indicator>
+      </Progress.Root>
       <div className="mt-1 text-right text-xs text-black/60">{pct}%</div>
     </div>
   );

--- a/src/components/onboarding/step-indicator.tsx
+++ b/src/components/onboarding/step-indicator.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { motion } from "motion/react";
+
 type StepIndicatorProps = {
   steps: string[];
   current: number;
@@ -12,14 +14,17 @@ export default function StepIndicator({ steps, current }: StepIndicatorProps) {
         const active = idx <= current;
         return (
           <li key={label} className="flex items-center gap-3">
-            <span
-              className={
-                "flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium " +
-                (active ? "bg-brand text-brand-foreground" : "bg-black/5 text-black/60")
-              }
+            <motion.span
+              className="flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium"
+              animate={{
+                backgroundColor: active ? "var(--brand)" : "rgba(0,0,0,0.05)",
+                color: active ? "var(--brand-foreground)" : "rgba(0,0,0,0.6)",
+                scale: active ? 1.1 : 1,
+              }}
+              transition={{ type: "spring", stiffness: 300, damping: 20 }}
             >
               {idx + 1}
-            </span>
+            </motion.span>
             <span className="text-sm font-medium text-black/70">{label}</span>
           </li>
         );

--- a/src/components/onboarding/transition-layout.tsx
+++ b/src/components/onboarding/transition-layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion } from "motion/react";
 import { usePathname } from "next/navigation";
 
 const variants = {

--- a/src/components/profile/profile-form.tsx
+++ b/src/components/profile/profile-form.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+type ProfileInput = Partial<{
+  first_name: string;
+  last_name: string;
+  phone_number: string;
+  bio: string;
+  country: string;
+  city: string;
+  neighborhood: string;
+}>;
+
+export default function ProfileForm({ initial }: { initial: ProfileInput }) {
+  const [form, setForm] = useState<ProfileInput>({
+    first_name: initial.first_name || "",
+    last_name: initial.last_name || "",
+    phone_number: initial.phone_number || "",
+    bio: initial.bio || "",
+    country: initial.country || "",
+    city: initial.city || "",
+    neighborhood: initial.neighborhood || "",
+  });
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  async function save() {
+    setSaving(true);
+    setMessage(null);
+    try {
+      const res = await fetch("/api/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setMessage("Perfil actualizado");
+    } catch (e: any) {
+      setMessage(e?.message || "No se pudo guardar");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Field label="Nombre">
+          <Input value={form.first_name} onChange={(e) => setForm({ ...form, first_name: e.target.value })} />
+        </Field>
+        <Field label="Apellido">
+          <Input value={form.last_name} onChange={(e) => setForm({ ...form, last_name: e.target.value })} />
+        </Field>
+        <Field label="Teléfono">
+          <Input value={form.phone_number} onChange={(e) => setForm({ ...form, phone_number: e.target.value })} />
+        </Field>
+        <div />
+        <Field label="País">
+          <Input value={form.country} onChange={(e) => setForm({ ...form, country: e.target.value })} />
+        </Field>
+        <Field label="Ciudad">
+          <Input value={form.city} onChange={(e) => setForm({ ...form, city: e.target.value })} />
+        </Field>
+        <Field label="Barrio">
+          <Input value={form.neighborhood} onChange={(e) => setForm({ ...form, neighborhood: e.target.value })} />
+        </Field>
+        <div className="sm:col-span-2">
+          <Field label="Bio">
+            <Textarea value={form.bio} onChange={(e) => setForm({ ...form, bio: e.target.value })} />
+          </Field>
+        </div>
+      </div>
+      {message && <p className="mt-3 text-sm text-black/60">{message}</p>}
+      <div className="mt-4 flex justify-end">
+        <Button onClick={save} disabled={saving}>
+          {saving ? "Guardando..." : "Guardar"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="grid gap-2">
+      <span className="text-sm font-medium text-black/80">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      {...props}
+      className={
+        "h-10 w-full rounded-lg border border-black/10 bg-white px-3 text-sm text-black placeholder:text-black/40 focus:outline-none focus:ring-2 focus:ring-black/20 " +
+        (props.className || "")
+      }
+    />
+  );
+}
+
+function Textarea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return (
+    <textarea
+      {...props}
+      className={
+        "min-h-24 w-full rounded-lg border border-black/10 bg-white p-3 text-sm text-black placeholder:text-black/40 focus:outline-none focus:ring-2 focus:ring-black/20 " +
+        (props.className || "")
+      }
+    />
+  );
+}
+

--- a/src/components/profile/user-profile-panel.tsx
+++ b/src/components/profile/user-profile-panel.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { UserProfile } from "@clerk/nextjs";
+
+export default function UserProfilePanel() {
+  return (
+    <div className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
+      <UserProfile
+        appearance={{
+          elements: {
+            card: "shadow-none border-0",
+            navbar: "hidden",
+          },
+        }}
+      />
+    </div>
+  );
+}
+

--- a/src/components/profiles/profile-card.tsx
+++ b/src/components/profiles/profile-card.tsx
@@ -1,27 +1,43 @@
+import Link from "next/link";
+import { fileUrl } from "@/services/pb";
+
 type Profile = {
   id: string;
   first_name?: string;
   last_name?: string;
-  bio?: string;
   city?: string;
   country?: string;
   neighborhood?: string;
-  roles?: string[];
-  links?: any;
+  avatar?: string;
+  rating?: number;
 };
 
-export default function ProfileCard({ profile }: { profile: Profile }) {
+export default function ProfileCard({ profile, subcategory }: { profile: Profile; subcategory?: string }) {
   const name = [profile.first_name, profile.last_name].filter(Boolean).join(" ") || "Perfil";
   const location = [profile.neighborhood, profile.city, profile.country].filter(Boolean).join(", ");
+  const image = profile.avatar ? fileUrl("profiles", profile.id, profile.avatar) : null;
 
   return (
-    <article className="group overflow-hidden rounded-2xl border border-black/10 bg-white shadow-sm transition hover:shadow-md">
-      <div className="grid gap-2 p-4">
-        <h3 className="text-base font-semibold text-black/90 line-clamp-1">{name}</h3>
-        {location && <div className="text-xs text-black/60">{location}</div>}
-        {profile.bio && <p className="text-sm text-black/70 line-clamp-2">{profile.bio}</p>}
-      </div>
-    </article>
+    <Link href={`/profesionales/${profile.id}`} className="block">
+      <article className="group overflow-hidden rounded-2xl border border-brand/10 bg-white shadow-sm transition hover:shadow-md">
+        {image ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={image} alt="Foto del perfil" className="h-40 w-full object-cover" />
+        ) : (
+          <div className="h-40 w-full bg-brand/5" />
+        )}
+        <div className="grid gap-2 p-4">
+          <div className="flex items-start justify-between gap-3">
+            <h3 className="line-clamp-1 text-base font-semibold text-foreground">{name}</h3>
+            {typeof profile.rating === "number" && (
+              <span className="text-xs text-black">{profile.rating.toFixed(1)}</span>
+            )}
+          </div>
+          {subcategory && <div className="text-sm text-black">{subcategory}</div>}
+          {location && <div className="text-xs text-muted-foreground">{location}</div>}
+        </div>
+      </article>
+    </Link>
   );
 }
 

--- a/src/components/profiles/profile-card.tsx
+++ b/src/components/profiles/profile-card.tsx
@@ -31,18 +31,18 @@ export default function ProfileCard({ profile, subcategory }: { profile: Profile
           <div className="flex items-start justify-between gap-3">
             <h3 className="line-clamp-1 text-base font-semibold text-foreground">{name}</h3>
             {typeof profile.rating === "number" && (
-              <div className="flex items-center gap-1 text-xs text-brand">
+              <div className="flex items-center gap-1 text-xs text-black">
                 <Star className="h-4 w-4 fill-brand text-brand" />
                 {profile.rating.toFixed(1)}
               </div>
             )}
           </div>
           {subcategory && (
-            <span className="inline-block rounded-full bg-brand/10 px-2 py-0.5 text-xs text-brand">{subcategory}</span>
+            <span className="inline-block rounded-full bg-brand/10 px-2 py-0.5 text-xs text-black">{subcategory}</span>
           )}
           {location && (
             <div className="flex items-center gap-1 text-xs text-muted-foreground">
-              <MapPin className="h-3.5 w-3.5 text-brand" />
+              <MapPin className="h-3.5 w-3.5 text-black" />
               <span>{location}</span>
             </div>
           )}

--- a/src/components/profiles/profile-card.tsx
+++ b/src/components/profiles/profile-card.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { fileUrl } from "@/services/pb";
+import { Star, MapPin } from "lucide-react";
 
 type Profile = {
   id: string;
@@ -30,11 +31,21 @@ export default function ProfileCard({ profile, subcategory }: { profile: Profile
           <div className="flex items-start justify-between gap-3">
             <h3 className="line-clamp-1 text-base font-semibold text-foreground">{name}</h3>
             {typeof profile.rating === "number" && (
-              <span className="text-xs text-black">{profile.rating.toFixed(1)}</span>
+              <div className="flex items-center gap-1 text-xs text-brand">
+                <Star className="h-4 w-4 fill-brand text-brand" />
+                {profile.rating.toFixed(1)}
+              </div>
             )}
           </div>
-          {subcategory && <div className="text-sm text-black">{subcategory}</div>}
-          {location && <div className="text-xs text-muted-foreground">{location}</div>}
+          {subcategory && (
+            <span className="inline-block rounded-full bg-brand/10 px-2 py-0.5 text-xs text-brand">{subcategory}</span>
+          )}
+          {location && (
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <MapPin className="h-3.5 w-3.5 text-brand" />
+              <span>{location}</span>
+            </div>
+          )}
         </div>
       </article>
     </Link>

--- a/src/components/profiles/profiles-filters.tsx
+++ b/src/components/profiles/profiles-filters.tsx
@@ -36,23 +36,23 @@ export default function ProfilesFilters({ category }: { category: CategoryKey })
   }
 
   return (
-    <div className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
+    <div className="rounded-2xl border border-brand/10 bg-white p-4 shadow-sm">
       <div className="grid grid-cols-1 gap-3 md:grid-cols-5">
         <div className="md:col-span-2">
-          <label className="mb-1 block text-xs font-medium text-black/70">Buscar</label>
+          <label className="mb-1 block text-xs font-medium text-black">Buscar</label>
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Nombre o bio"
-            className="h-10 w-full rounded-lg border border-black/10 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/20"
+            className="h-10 w-full rounded-lg border border-black bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/40"
           />
         </div>
         <div>
-          <label className="mb-1 block text-xs font-medium text-black/70">Subcategoría</label>
+          <label className="mb-1 block text-xs font-medium text-black">Subcategoría</label>
           <select
             value={subcat}
             onChange={(e) => setSubcat(e.target.value)}
-            className="h-10 w-full rounded-lg border border-black/10 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/20"
+            className="h-10 w-full rounded-lg border border-black bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/40"
           >
             <option value="">Todas</option>
             {options.map((o) => (
@@ -63,21 +63,21 @@ export default function ProfilesFilters({ category }: { category: CategoryKey })
           </select>
         </div>
         <div>
-          <label className="mb-1 block text-xs font-medium text-black/70">Ciudad</label>
+          <label className="mb-1 block text-xs font-medium text-black">Ciudad</label>
           <input
             value={city}
             onChange={(e) => setCity(e.target.value)}
             placeholder="Ciudad"
-            className="h-10 w-full rounded-lg border border-black/10 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/20"
+            className="h-10 w-full rounded-lg border border-black bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/40"
           />
         </div>
         <div>
-          <label className="mb-1 block text-xs font-medium text-black/70">Barrio</label>
+          <label className="mb-1 block text-xs font-medium text-black">Barrio</label>
           <input
             value={hood}
             onChange={(e) => setHood(e.target.value)}
             placeholder="Barrio"
-            className="h-10 w-full rounded-lg border border-black/10 bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/20"
+            className="h-10 w-full rounded-lg border border-black bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/40"
           />
         </div>
       </div>

--- a/src/components/profiles/profiles-header.tsx
+++ b/src/components/profiles/profiles-header.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState, useTransition } from "react";
 import { SUBCATEGORY_OPTIONS, type CategoryKey } from "@/lib/categories";
+import { Search, SlidersHorizontal } from "lucide-react";
 
 export default function ProfilesHeader({ category }: { category: CategoryKey }) {
   const router = useRouter();
@@ -35,18 +36,22 @@ export default function ProfilesHeader({ category }: { category: CategoryKey }) 
 
   return (
     <div>
-      <form onSubmit={onSubmit} className="flex gap-2">
-        <input
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-          placeholder="Buscar profesionales por nombre, oficio o especialidad..."
-          className="h-10 w-full flex-1 rounded-lg border border-black bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/40"
-        />
+      <form onSubmit={onSubmit} className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-brand" />
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Buscar profesionales por nombre, oficio o especialidad..."
+            className="h-10 w-full rounded-lg border border-brand bg-white pl-9 pr-3 text-sm text-brand placeholder:text-brand/60 focus:outline-none focus:ring-2 focus:ring-brand/40"
+          />
+        </div>
         <button
           type="button"
           onClick={() => setShowFilters((v) => !v)}
-          className="h-10 rounded-lg border border-brand bg-brand px-3 text-sm font-medium text-brand-foreground"
+          className="flex h-10 items-center gap-1 rounded-lg border border-brand bg-brand px-3 text-sm font-medium text-brand-foreground"
         >
+          <SlidersHorizontal className="h-4 w-4" />
           Filtros
         </button>
       </form>
@@ -55,7 +60,7 @@ export default function ProfilesHeader({ category }: { category: CategoryKey }) 
           <button
             onClick={() => updateSearch({ subcat: "" })}
             className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
-              currentSub ? "border-brand/20 text-black" : "border-brand bg-brand text-brand-foreground"
+              currentSub ? "border-brand text-brand" : "border-brand bg-brand text-brand-foreground"
             }`}
             disabled={isPending}
           >
@@ -68,7 +73,7 @@ export default function ProfilesHeader({ category }: { category: CategoryKey }) 
               className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
                 currentSub === o.key
                   ? "border-brand bg-brand text-brand-foreground"
-                  : "border-brand/20 text-black"
+                  : "border-brand text-brand"
               }`}
               disabled={isPending}
             >

--- a/src/components/profiles/profiles-header.tsx
+++ b/src/components/profiles/profiles-header.tsx
@@ -38,12 +38,12 @@ export default function ProfilesHeader({ category }: { category: CategoryKey }) 
     <div>
       <form onSubmit={onSubmit} className="flex items-center gap-2">
         <div className="relative flex-1">
-          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-brand" />
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-black" />
           <input
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Buscar profesionales por nombre, oficio o especialidad..."
-            className="h-10 w-full rounded-lg border border-brand bg-white pl-9 pr-3 text-sm text-brand placeholder:text-brand/60 focus:outline-none focus:ring-2 focus:ring-brand/40"
+            className="h-10 w-full rounded-lg border border-brand bg-white pl-9 pr-3 text-sm text-black placeholder:text-black/60 focus:outline-none focus:ring-2 focus:ring-brand/40"
           />
         </div>
         <button
@@ -60,7 +60,7 @@ export default function ProfilesHeader({ category }: { category: CategoryKey }) 
           <button
             onClick={() => updateSearch({ subcat: "" })}
             className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
-              currentSub ? "border-brand text-brand" : "border-brand bg-brand text-brand-foreground"
+              currentSub ? "border-brand text-black" : "border-brand bg-brand text-brand-foreground"
             }`}
             disabled={isPending}
           >
@@ -73,7 +73,7 @@ export default function ProfilesHeader({ category }: { category: CategoryKey }) 
               className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
                 currentSub === o.key
                   ? "border-brand bg-brand text-brand-foreground"
-                  : "border-brand text-brand"
+                  : "border-brand text-black"
               }`}
               disabled={isPending}
             >

--- a/src/components/profiles/profiles-header.tsx
+++ b/src/components/profiles/profiles-header.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState, useTransition } from "react";
+import { SUBCATEGORY_OPTIONS, type CategoryKey } from "@/lib/categories";
+
+export default function ProfilesHeader({ category }: { category: CategoryKey }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const [q, setQ] = useState(params.get("q") || "");
+  const [showFilters, setShowFilters] = useState(false);
+  const currentSub = params.get("subcat") || "";
+  const options = SUBCATEGORY_OPTIONS[category];
+
+  function updateSearch(next: { q?: string; subcat?: string }) {
+    const sp = new URLSearchParams(params.toString());
+    if (next.q !== undefined) {
+      if (next.q) sp.set("q", next.q);
+      else sp.delete("q");
+    }
+    if (next.subcat !== undefined) {
+      if (next.subcat) sp.set("subcat", next.subcat);
+      else sp.delete("subcat");
+    }
+    startTransition(() => router.push(`${pathname}?${sp.toString()}`));
+  }
+
+  function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    updateSearch({ q });
+  }
+
+  return (
+    <div>
+      <form onSubmit={onSubmit} className="flex gap-2">
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Buscar profesionales por nombre, oficio o especialidad..."
+          className="h-10 w-full flex-1 rounded-lg border border-black bg-white px-3 text-sm focus:outline-none focus:ring-2 focus:ring-black/40"
+        />
+        <button
+          type="button"
+          onClick={() => setShowFilters((v) => !v)}
+          className="h-10 rounded-lg border border-brand bg-brand px-3 text-sm font-medium text-brand-foreground"
+        >
+          Filtros
+        </button>
+      </form>
+      {showFilters && (
+        <div className="mt-4 flex gap-2 overflow-x-auto">
+          <button
+            onClick={() => updateSearch({ subcat: "" })}
+            className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
+              currentSub ? "border-brand/20 text-black" : "border-brand bg-brand text-brand-foreground"
+            }`}
+            disabled={isPending}
+          >
+            Todos
+          </button>
+          {options.map((o) => (
+            <button
+              key={o.key}
+              onClick={() => updateSearch({ subcat: o.key })}
+              className={`whitespace-nowrap rounded-full border px-3 py-1 text-xs ${
+                currentSub === o.key
+                  ? "border-brand bg-brand text-brand-foreground"
+                  : "border-brand/20 text-black"
+              }`}
+              disabled={isPending}
+            >
+              {o.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/profiles/profiles-list.tsx
+++ b/src/components/profiles/profiles-list.tsx
@@ -58,7 +58,7 @@ export default async function ProfilesList({
   const count = profiles.length;
   return (
     <div>
-      <div className="mb-4 text-sm text-black/80">{`Mostrando ${count} profesionales`}</div>
+      <div className="mb-4 text-sm text-brand">{`Mostrando ${count} profesionales`}</div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {profiles.map(({ profile, subcat }) => {
           const label = SUBCATEGORY_OPTIONS[category].find((o) => o.key === subcat)?.label;

--- a/src/components/profiles/profiles-list.tsx
+++ b/src/components/profiles/profiles-list.tsx
@@ -58,7 +58,7 @@ export default async function ProfilesList({
   const count = profiles.length;
   return (
     <div>
-      <div className="mb-4 text-sm text-brand">{`Mostrando ${count} profesionales`}</div>
+      <div className="mb-4 text-sm text-black">{`Mostrando ${count} profesionales`}</div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {profiles.map(({ profile, subcat }) => {
           const label = SUBCATEGORY_OPTIONS[category].find((o) => o.key === subcat)?.label;

--- a/src/components/profiles/profiles-list.tsx
+++ b/src/components/profiles/profiles-list.tsx
@@ -1,10 +1,19 @@
 import { getPocketBase } from "@/services/pb";
 import ProfileCard from "@/components/profiles/profile-card";
+import { SUBCATEGORY_OPTIONS } from "@/lib/categories";
 
 type Category = "workers" | "creators" | "providers";
 
-export default async function ProfilesList({ category, limit = 30, filters }: { category: Category; limit?: number; filters?: { q?: string; subcat?: string; city?: string; hood?: string } }) {
-  let profiles: any[] = [];
+export default async function ProfilesList({
+  category,
+  limit = 30,
+  filters,
+}: {
+  category: Category;
+  limit?: number;
+  filters?: { q?: string; subcat?: string; city?: string; hood?: string };
+}) {
+  let profiles: { profile: any; subcat?: string }[] = [];
   try {
     const pb = getPocketBase();
     const subFilter = filters?.subcat ? ` && subcategory = "${filters.subcat}"` : "";
@@ -13,10 +22,10 @@ export default async function ProfilesList({ category, limit = 30, filters }: { 
       expand: "profile_id",
       sort: "-created",
     });
-    const map = new Map<string, any>();
+    const map = new Map<string, { profile: any; subcat?: string }>();
     for (const it of res.items) {
       const p = (it as any).expand?.profile_id;
-      if (p && !map.has(p.id)) map.set(p.id, p);
+      if (p && !map.has(p.id)) map.set(p.id, { profile: p, subcat: (it as any).subcategory });
     }
     profiles = Array.from(map.values());
 
@@ -24,7 +33,7 @@ export default async function ProfilesList({ category, limit = 30, filters }: { 
     const q = filters?.q?.toLowerCase().trim();
     const city = filters?.city?.toLowerCase().trim();
     const hood = filters?.hood?.toLowerCase().trim();
-    profiles = profiles.filter((p) => {
+    profiles = profiles.filter(({ profile: p }) => {
       const name = `${p.first_name || ""} ${p.last_name || ""}`.toLowerCase();
       const bio = (p.bio || "").toLowerCase();
       const pCity = (p.city || "").toLowerCase();
@@ -40,17 +49,22 @@ export default async function ProfilesList({ category, limit = 30, filters }: { 
 
   if (!profiles.length) {
     return (
-      <div className="rounded-2xl border border-black/10 bg-white p-8 text-center text-sm text-black/60">
+      <div className="rounded-2xl border border-brand/10 bg-white p-8 text-center text-sm text-muted-foreground">
         No hay resultados por el momento.
       </div>
     );
   }
 
+  const count = profiles.length;
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {profiles.map((p) => (
-        <ProfileCard key={p.id} profile={p} />
-      ))}
+    <div>
+      <div className="mb-4 text-sm text-black/80">{`Mostrando ${count} profesionales`}</div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {profiles.map(({ profile, subcat }) => {
+          const label = SUBCATEGORY_OPTIONS[category].find((o) => o.key === subcat)?.label;
+          return <ProfileCard key={profile.id} profile={profile} subcategory={label} />;
+        })}
+      </div>
     </div>
   );
 }

--- a/src/components/profiles/profiles-skeleton.tsx
+++ b/src/components/profiles/profiles-skeleton.tsx
@@ -2,7 +2,7 @@ export default function ProfilesSkeleton() {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {Array.from({ length: 6 }).map((_, i) => (
-        <div key={i} className="rounded-2xl border border-black/10 bg-white p-4 shadow-sm">
+        <div key={i} className="rounded-2xl border border-brand/10 bg-white p-4 shadow-sm">
           <div className="skeleton mb-3 h-5 w-1/2"></div>
           <div className="skeleton mb-2 h-3 w-1/3"></div>
           <div className="skeleton h-4 w-full"></div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,36 +1,50 @@
 "use client";
 
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/cn";
-import React from "react";
 
-type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: "default" | "outline";
-  size?: "sm" | "md" | "icon";
-  asChild?: boolean;
-  className?: string;
-};
-
-export function Button({ variant = "default", size = "md", asChild, className, children, ...props }: ButtonProps) {
-  const base = "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors disabled:opacity-50 disabled:pointer-events-none";
-  const variantCls = variant === "outline"
-    ? "border border-black/10 bg-white hover:bg-[#f6f6f6] text-black"
-    : "bg-brand text-brand-foreground hover:opacity-90";
-  const sizeCls = size === "sm" ? "h-9 px-3"
-    : size === "icon" ? "h-9 w-9"
-    : "h-10 px-4";
-
-  const cls = cn(base, variantCls, sizeCls, className);
-
-  if (asChild && React.isValidElement(children)) {
-    return React.cloneElement(children as any, {
-      className: cn((children as any).props?.className, cls),
-    });
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-brand text-brand-foreground hover:opacity-90",
+        outline: "border border-brand bg-transparent hover:bg-brand/10 text-brand",
+      },
+      size: {
+        default: "h-10 px-4",
+        sm: "h-9 px-3",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
   }
+);
 
-  return (
-    <button className={cls} {...props}>
-      {children}
-    </button>
-  );
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
 }
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };
 

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,35 +1,19 @@
 "use client";
 
+import * as React from "react";
+import { Label } from "./label";
+import { Input as InputBase } from "./input";
+import { Textarea as TextareaBase } from "./textarea";
+
 export function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <label className="grid gap-2">
-      <span className="text-sm font-medium text-black/80">{label}</span>
+    <div className="grid gap-2">
+      <Label>{label}</Label>
       {children}
-    </label>
+    </div>
   );
 }
 
-export function Input(props: React.InputHTMLAttributes<HTMLInputElement>) {
-  return (
-    <input
-      {...props}
-      className={
-        "h-10 rounded-lg border border-black/10 bg-white px-3 text-sm text-black placeholder:text-black/40 focus:outline-none focus:ring-2 focus:ring-black/20 " +
-        (props.className || "")
-      }
-    />
-  );
-}
-
-export function Textarea(props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
-  return (
-    <textarea
-      {...props}
-      className={
-        "min-h-24 rounded-lg border border-black/10 bg-white p-3 text-sm text-black placeholder:text-black/40 focus:outline-none focus:ring-2 focus:ring-black/20 " +
-        (props.className || "")
-      }
-    />
-  );
-}
+export const Input = InputBase;
+export const Textarea = TextareaBase;
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-brand/20 bg-white px-3 py-2 text-sm ring-offset-background placeholder:text-brand/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };
+

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn("text-sm font-medium text-brand", className)}
+      {...props}
+    />
+  )
+);
+Label.displayName = "Label";
+
+export { Label };
+

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/cn";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex w-full rounded-md border border-brand/20 bg-white px-3 py-2 text-sm ring-offset-background placeholder:text-brand/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };
+

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -1,4 +1,7 @@
-export function cn(...classes: Array<string | false | null | undefined>) {
-  return classes.filter(Boolean).join(" ");
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
 }
 


### PR DESCRIPTION
## Summary
- install shadcn ui utilities and sweetalert2
- refactor job form to use shadcn primitives and SweetAlert2 notifications

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a20eda80a48328af1ea1c846d411ab